### PR TITLE
Add mobile-friendly channel toggle for PakStream TV page

### DIFF
--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -46,6 +46,35 @@
       flex-direction: row;
       padding: 20px;
     }
+    .channel-toggle {
+      display: none;
+      margin-bottom: 10px;
+      padding: 8px 12px;
+    }
+    @media (max-width: 768px) {
+      .channel-toggle {
+        display: block;
+      }
+      .channel-list {
+        display: none;
+        max-width: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: #fff;
+        z-index: 1500;
+        padding: 20px;
+        overflow-y: auto;
+      }
+      .channel-list.open {
+        display: block;
+      }
+      .video-section {
+        padding-left: 0;
+      }
+    }
   </style>
 </head>
 <body>
@@ -75,6 +104,7 @@
 
   <!-- TV Livestream section -->
   <section class="youtube-section">
+    <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()">Channels</button>
     <div class="channel-list">
       <div class="channel-card" onclick="showStream('geo', this)">Geo News</div>
       <div class="channel-card" onclick="showStream('ary', this)">ARY News</div>
@@ -157,7 +187,7 @@
         players[id] = new YT.Player(id);
       });
     }
-    
+
     function showStream(id, element) {
       // Hide all video divs
       document.querySelectorAll('.live-player').forEach(div => div.style.display = 'none');
@@ -185,6 +215,20 @@
       // Update URL without reloading
       const newUrl = `${window.location.pathname}?tvchannel=${id}`;
       history.replaceState(null, '', newUrl);
+
+      // Close channel list on small screens
+      if (window.innerWidth <= 768) {
+        const list = document.querySelector('.channel-list');
+        list.classList.remove('open');
+        document.getElementById('toggle-channels').textContent = 'Channels';
+      }
+    }
+
+    function toggleChannelList() {
+      const list = document.querySelector('.channel-list');
+      const btn = document.getElementById('toggle-channels');
+      list.classList.toggle('open');
+      btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
     }
 
     // Auto-select based on ?tvchannel=ary etc.


### PR DESCRIPTION
## Summary
- Add responsive channel list toggle so TV page uses full screen on mobile
- Automatically hide channel list after selecting a stream

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e971fc84c8320bcd0a642468fcd66