### PR TITLE
Make live-player iframe responsive

### DIFF
--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -21,7 +21,7 @@
     
     .live-player iframe {
       width: 100%;
-      height: 500px;
+      aspect-ratio: 16 / 9;
       border: none;
     }
     .channel-list {


### PR DESCRIPTION
## Summary
- replace fixed height with 16:9 aspect ratio on live TV player iframe

## Testing
- `npm test` *(fails: package.json not found)*
- `pip install playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e9c8937c08320ba2af3a4b600c9b9