### PR TITLE
feat: add spinner for radio play buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,3 +87,37 @@ nav a {
     margin: 15px 0;
   }
 }
+
+/* Spinner styles for radio play buttons */
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 60px;
+}
+
+.play-btn .spinner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/radio.html
+++ b/radio.html
@@ -461,6 +461,12 @@ document.addEventListener('DOMContentLoaded', function() {
     audio.preload = 'none';
     const button = audio.nextElementSibling;
     if (!button || !button.classList.contains('play-btn')) return;
+
+    // initialize button with label and hidden spinner
+    button.innerHTML = '<span class="label">Play</span><span class="spinner" aria-hidden="true"></span>';
+    const btnWidth = button.offsetWidth;
+    button.style.width = btnWidth + 'px';
+
     button.addEventListener('click', function() {
       // pause all other audio streams and reset their buttons
       players.forEach(function(other) {
@@ -468,27 +474,33 @@ document.addEventListener('DOMContentLoaded', function() {
           other.pause();
           const otherBtn = other.nextElementSibling;
           if (otherBtn && otherBtn.classList.contains('play-btn')) {
-            otherBtn.textContent = 'Play';
+            otherBtn.classList.remove('loading');
+            otherBtn.disabled = false;
+            const otherLabel = otherBtn.querySelector('.label');
+            if (otherLabel) otherLabel.textContent = 'Play';
           }
         }
       });
       // toggle play/pause on selected audio with loading indicator
       if (audio.paused) {
         // show loading state while the network request is in progress
-        button.textContent = 'Loading...';
+        button.classList.add('loading');
         button.disabled = true;
         const playPromise = audio.play();
         if (playPromise !== undefined) {
           playPromise.catch(function(err) {
             // handle autoplay restrictions or other errors
             button.disabled = false;
-            button.textContent = 'Play';
+            button.classList.remove('loading');
+            const label = button.querySelector('.label');
+            if (label) label.textContent = 'Play';
             console.error(err);
           });
         }
       } else {
         audio.pause();
-        button.textContent = 'Play';
+        const label = button.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // when the audio starts playing, update the button text to Stop
@@ -496,7 +508,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Stop';
       }
     });
     // when enough data has been downloaded to begin playing, update the button (canplay is often fired before playing)
@@ -504,7 +518,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
     // also handle canplaythrough (buffered enough to play through to end without stalling)
@@ -512,7 +528,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
     // when audio is waiting/buffering, show Loading
@@ -520,7 +538,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = true;
-        btn.textContent = 'Loading...';
+        btn.classList.add('loading');
       }
     });
     // when the audio ends, reset button label
@@ -528,7 +546,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Play';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // if paused by user, update label
@@ -538,7 +558,9 @@ document.addEventListener('DOMContentLoaded', function() {
         // if pause not due to ended event, show Play
         if (!audio.ended) {
           btn.disabled = false;
-          btn.textContent = 'Play';
+          btn.classList.remove('loading');
+          const label = btn.querySelector('.label');
+          if (label) label.textContent = 'Play';
         }
       }
     });
@@ -547,10 +569,14 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         // briefly show an error message before resetting to Play
-        btn.textContent = 'Unavailable';
-        setTimeout(function() {
-          btn.textContent = 'Play';
-        }, 4000);
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) {
+          label.textContent = 'Unavailable';
+          setTimeout(function() {
+            label.textContent = 'Play';
+          }, 4000);
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- show animated spinner for radio play button loading state
- keep play button width fixed to prevent size changes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb01020548320a5bfa0ea17318dd7