### PR TITLE
feat: add spinner for radio play buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,3 +87,37 @@ nav a {
     margin: 15px 0;
   }
 }
+
+/* Spinner styles for radio play buttons */
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 60px;
+}
+
+.play-btn .spinner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/pakradio.html
+++ b/pakradio.html
@@ -63,322 +63,258 @@
   <tr>
     <th>Station</th>
     <th>Listen</th>
-    <th>Notes</th>
   </tr>
   <tr>
     <td class="station-name">#radio quran</td>
     <td><audio id="audio1" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">101peshawar</td>
     <td><audio id="audio2" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Abdulbasit Abdulsamad</td>
     <td><audio id="audio3" src="https://radio.mp3islam.com/listen/abdulbasit/radio.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">AK radio Trarkhal</td>
     <td><audio id="audio4" src="https://whmsonic.radio.gov.pk:8076/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Aladin Radio Network</td>
     <td><audio id="audio5" src="https://cc.vmakerhost.com/proxy/magic?mp=/live"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">All4Masti</td>
     <td><audio id="audio6" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">BAHAWAL PUR MW STATION</td>
     <td><audio id="audio7" src="https://whmsonic.radio.gov.pk:8088/stream?type=http&amp;nocache=4"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">City FM 89</td>
     <td><audio id="audio8" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">City FM 89 Islamabad</td>
     <td><audio id="audio9" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">fm</td>
     <td><audio id="audio10" src="https://canada1.reliastream.com:8191/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan</td>
     <td><audio id="audio11" src="https://162.244.80.118:4900/;stream.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Abbottabad</td>
     <td><audio id="audio12" src="https://162.244.80.118:4900/stream.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Gujrat</td>
     <td><audio id="audio13" src="https://162.244.80.118:4900/stream.mp3?ver=682776"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Hyderabad</td>
     <td><audio id="audio14" src="https://162.244.80.118:3024/stream.mp3?ver=517748"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Islamabad</td>
     <td><audio id="audio15" src="https://162.244.80.118:4900/stream.mp3?ver=604498"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Jhelum</td>
     <td><audio id="audio16" src="https://162.244.80.118:4900/stream.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 100 Pakistan Karachi</td>
     <td><audio id="audio17" src="https://162.244.80.118:3024/stream.mp3?ver=349829"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 101 Islamabad</td>
     <td><audio id="audio18" src="https://whmsonic.radio.gov.pk:7008/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 101 Karachi</td>
     <td><audio id="audio19" src="https://whmsonic.radio.gov.pk:8048/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 101 Larkana</td>
     <td><audio id="audio20" src="https://whmsonic.radio.gov.pk:8050/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 101 Mithi</td>
     <td><audio id="audio21" src="https://whmsonic.radio.gov.pk:8052/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Chitral</td>
     <td><audio id="audio22" src="https://whmsonic.radio.gov.pk:8066/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Faisalabad</td>
     <td><audio id="audio23" src="https://whmsonic.radio.gov.pk:8022/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Karachi</td>
     <td><audio id="audio24" src="https://whmsonic.radio.gov.pk:7022/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Lahore</td>
     <td><audio id="audio25" src="https://whmsonic.radio.gov.pk:8088/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Mianwali</td>
     <td><audio id="audio26" src="https://whmsonic.radio.gov.pk:8028/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Multan</td>
     <td><audio id="audio27" src="https://whmsonic.radio.gov.pk:8032/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">FM 93 Rawalpindi</td>
     <td><audio id="audio28" src="https://whmsonic.radio.gov.pk:8036/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">fm...</td>
     <td><audio id="audio29" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGPu7EAAYqZ0ars2sgeryA"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">fm...</td>
     <td><audio id="audio30" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">fm.92</td>
     <td><audio id="audio31" src="https://s33.myradiostream.com:13872/listen.m4a"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Fm.94.4</td>
     <td><audio id="audio32" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Hot FM 105</td>
     <td><audio id="audio33" src="https://172.93.237.106:8000/listen.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">HOT FM Karachi</td>
     <td><audio id="audio34" src="https://172.93.237.106:8000/"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Hum FM 106.2</td>
     <td><audio id="audio35" src="https://server.mediacast4u.stream/8002/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">ILM Radio Renala FM 92</td>
     <td><audio id="audio36" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Insaf Radio</td>
     <td><audio id="audio37" src="https://cdn.voscast.com/resources/?key=4e1e2d7ac97ea7ad9493c529df2ab16c&amp;c=wmp"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">live</td>
     <td><audio id="audio38" src="https://live.mp3quran.net:9752/"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Love-Islam-Radio</td>
     <td><audio id="audio39" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Mera FM 107.4</td>
     <td><audio id="audio40" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Mera FM 107.4 Lahore</td>
     <td><audio id="audio41" src="https://samaalhr107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Multan MW</td>
     <td><audio id="audio42" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">naat</td>
     <td><audio id="audio43" src="https://philae.shoutca.st:8640/naat"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Papa John&#x27;s Pizza Pakistan</td>
     <td><audio id="audio44" src="https://162.252.85.85:7086/"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Mirpur</td>
     <td><audio id="audio45" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio One FM 91</td>
     <td><audio id="audio46" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio One FM 91 Gwadar</td>
     <td><audio id="audio47" src="https://cc.vmakerhost.com:8147/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pak Filmi</td>
     <td><audio id="audio48" src="https://74.91.125.187:8214/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Hyderabad MW 1008 KHz</td>
     <td><audio id="audio49" src="https://whmsonic.radio.gov.pk:8042/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Islamabad</td>
     <td><audio id="audio50" src="https://whmsonic.radio.gov.pk:7003/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Lahore</td>
     <td><audio id="audio51" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Lahore News and Current Affair AM 1332 KHZ</td>
     <td><audio id="audio52" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Multan</td>
     <td><audio id="audio53" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Multan MW</td>
     <td><audio id="audio54" src="https://whmsonic.radio.gov.pk:8034/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Peshawar MW</td>
     <td><audio id="audio55" src="https://whmsonic.radio.gov.pk:8072/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan Quetta MW</td>
     <td><audio id="audio56" src="https://whmsonic.radio.gov.pk:8060/relay"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan World Service</td>
     <td><audio id="audio57" src="https://whmsonic.radio.gov.pk:7005/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Radio Pakistan WS</td>
     <td><audio id="audio58" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Samaa FM 107.4</td>
     <td><audio id="audio59" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Shopen Anime Radio</td>
     <td><audio id="audio60" src="https://s97.radiolize.com:8040/radio.mp3"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</td>
     <td><audio id="audio61" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">Suno FM 89.4</td>
     <td><audio id="audio62" src="https://110.93.246.72:8000/SUNO"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <tr>
     <td class="station-name">পাকিস্তান</td>
     <td><audio id="audio63" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
-    <td></td>
   </tr>
   <!-- Additional stations discovered via StreamURL.link -->
   <tr>

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -441,3 +441,37 @@ footer {
     margin-top: 10px;
   }
 }
+
+/* Spinner styles for radio play buttons */
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 60px;
+}
+
+.play-btn .spinner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -42,232 +42,186 @@
         <tr>
           <th>Listen</th>
           <th>Station</th>
-          <th>Notes</th>
         </tr>
         <tr>
           <td><audio id="audio1" preload="none" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">#radio quran</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio2" preload="none" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">101peshawar</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio5" preload="none" src="https://cc.vmakerhost.com/proxy/magic?mp=/live"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Aladin Radio Network</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio6" preload="none" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">All4Masti</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio7" preload="none" src="https://whmsonic.radio.gov.pk:8088/stream?type=http&amp;nocache=4"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">BAHAWAL PUR MW STATION</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio8" preload="none" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">City FM 89</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio9" preload="none" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">City FM 89 Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio18" preload="none" src="https://whmsonic.radio.gov.pk:7008/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio19" preload="none" src="https://whmsonic.radio.gov.pk:8048/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Karachi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio20" preload="none" src="https://whmsonic.radio.gov.pk:8050/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Larkana</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio21" preload="none" src="https://whmsonic.radio.gov.pk:8052/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Mithi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio22" preload="none" src="https://whmsonic.radio.gov.pk:8066/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Chitral</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio23" preload="none" src="https://whmsonic.radio.gov.pk:8022/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Faisalabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio24" preload="none" src="https://whmsonic.radio.gov.pk:7022/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Karachi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio25" preload="none" src="https://whmsonic.radio.gov.pk:8088/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio26" preload="none" src="https://whmsonic.radio.gov.pk:8028/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Mianwali</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio27" preload="none" src="https://whmsonic.radio.gov.pk:8032/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Multan</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio28" preload="none" src="https://whmsonic.radio.gov.pk:8036/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Rawalpindi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio29" preload="none" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGPu7EAAYqZ0ars2sgeryA"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm...</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio30" preload="none" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm...</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio31" preload="none" src="https://s33.myradiostream.com:13872/listen.m4a"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm.92</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio32" preload="none" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Fm.94.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio35" preload="none" src="https://server.mediacast4u.stream/8002/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Hum FM 106.2</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio36" preload="none" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">ILM Radio Renala FM 92</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio37" preload="none" src="https://cdn.voscast.com/resources/?key=4e1e2d7ac97ea7ad9493c529df2ab16c&amp;c=wmp"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Insaf Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio39" preload="none" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Love-Islam-Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio40" preload="none" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Mera FM 107.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio41" preload="none" src="https://samaalhr107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Mera FM 107.4 Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio42" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Multan MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio45" preload="none" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Mirpur</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio46" preload="none" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio One FM 91</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio49" preload="none" src="https://whmsonic.radio.gov.pk:8042/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Hyderabad MW 1008 KHz</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio50" preload="none" src="https://whmsonic.radio.gov.pk:7003/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio51" preload="none" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio52" preload="none" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Lahore News and Current Affair AM 1332 KHZ</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio53" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Multan</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio54" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Multan MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio55" preload="none" src="https://whmsonic.radio.gov.pk:8072/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Peshawar MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio56" preload="none" src="https://whmsonic.radio.gov.pk:8060/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Quetta MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio57" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan World Service</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio58" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan WS</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio59" preload="none" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Samaa FM 107.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio60" preload="none" src="https://s97.radiolize.com:8040/radio.mp3"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Shopen Anime Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio61" preload="none" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio63" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">পাকিস্তান</td>
-          <td></td>
         </tr>
         <!-- Additional stations discovered via StreamURL.link -->
         <tr>
@@ -466,6 +420,12 @@ document.addEventListener('DOMContentLoaded', function() {
     audio.preload = 'none';
     const button = audio.nextElementSibling;
     if (!button || !button.classList.contains('play-btn')) return;
+
+    // initialize button with label and hidden spinner
+    button.innerHTML = '<span class="label">Play</span><span class="spinner" aria-hidden="true"></span>';
+    const btnWidth = button.offsetWidth;
+    button.style.width = btnWidth + 'px';
+
     button.addEventListener('click', function() {
       // pause all other audio streams and reset their buttons
       players.forEach(function(other) {
@@ -473,27 +433,33 @@ document.addEventListener('DOMContentLoaded', function() {
           other.pause();
           const otherBtn = other.nextElementSibling;
           if (otherBtn && otherBtn.classList.contains('play-btn')) {
-            otherBtn.textContent = 'Play';
+            otherBtn.classList.remove('loading');
+            otherBtn.disabled = false;
+            const otherLabel = otherBtn.querySelector('.label');
+            if (otherLabel) otherLabel.textContent = 'Play';
           }
         }
       });
       // toggle play/pause on selected audio with loading indicator
       if (audio.paused) {
         // show loading state while the network request is in progress
-        button.textContent = 'Loading...';
+        button.classList.add('loading');
         button.disabled = true;
         const playPromise = audio.play();
         if (playPromise !== undefined) {
           playPromise.catch(function(err) {
             // handle autoplay restrictions or other errors
             button.disabled = false;
-            button.textContent = 'Play';
+            button.classList.remove('loading');
+            const label = button.querySelector('.label');
+            if (label) label.textContent = 'Play';
             console.error(err);
           });
         }
       } else {
         audio.pause();
-        button.textContent = 'Play';
+        const label = button.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // when the audio starts playing, update the button text to Stop
@@ -501,7 +467,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Stop';
       }
     });
     // when enough data has been downloaded to begin playing, update the button (canplay is often fired before playing)
@@ -509,7 +477,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
     // also handle canplaythrough (buffered enough to play through to end without stalling)
@@ -517,15 +487,17 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
-    // when audio is waiting/buffering, show Loading
+    // when audio is waiting/buffering, show spinner
     audio.addEventListener('waiting', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = true;
-        btn.textContent = 'Loading...';
+        btn.classList.add('loading');
       }
     });
     // when the audio ends, reset button label
@@ -533,7 +505,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Play';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // if paused by user, update label
@@ -543,7 +517,9 @@ document.addEventListener('DOMContentLoaded', function() {
         // if pause not due to ended event, show Play
         if (!audio.ended) {
           btn.disabled = false;
-          btn.textContent = 'Play';
+          btn.classList.remove('loading');
+          const label = btn.querySelector('.label');
+          if (label) label.textContent = 'Play';
         }
       }
     });
@@ -552,10 +528,14 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         // briefly show an error message before resetting to Play
-        btn.textContent = 'Unavailable';
-        setTimeout(function() {
-          btn.textContent = 'Play';
-        }, 4000);
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) {
+          label.textContent = 'Unavailable';
+          setTimeout(function() {
+            label.textContent = 'Play';
+          }, 4000);
+        }
       }
     });
   });

--- a/radio.html
+++ b/radio.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PakStream - Radio Stations</title>
-  <link rel="stylesheet" href="css/style.css">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
+     crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="pakstream/css/style.css">
 </head>
 <body class="radio-list">
   <!-- Header with navigation -->
@@ -17,13 +19,14 @@
     <nav>
       <ul>
         <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
+        <li><a href="pakstream/youtube.html">YouTube</a></li>
+        <li><a href="pakstream/tv.html">TV</a></li>
+        <li><a href="pakstream/radio.html">Radio</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="pakstream/about.html">About</a></li>
+        <li><a href="pakstream/contact.html">Contact</a></li>
+        <li><a href="pakstream/privacy.html">Privacy</a></li>
+        <li><a href="pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
   </header>
@@ -37,232 +40,186 @@
         <tr>
           <th>Listen</th>
           <th>Station</th>
-          <th>Notes</th>
         </tr>
         <tr>
           <td><audio id="audio1" preload="none" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">#radio quran</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio2" preload="none" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">101peshawar</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio5" preload="none" src="https://cc.vmakerhost.com/proxy/magic?mp=/live"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Aladin Radio Network</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio6" preload="none" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">All4Masti</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio7" preload="none" src="https://whmsonic.radio.gov.pk:8088/stream?type=http&amp;nocache=4"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">BAHAWAL PUR MW STATION</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio8" preload="none" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">City FM 89</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio9" preload="none" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">City FM 89 Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio18" preload="none" src="https://whmsonic.radio.gov.pk:7008/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio19" preload="none" src="https://whmsonic.radio.gov.pk:8048/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Karachi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio20" preload="none" src="https://whmsonic.radio.gov.pk:8050/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Larkana</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio21" preload="none" src="https://whmsonic.radio.gov.pk:8052/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 101 Mithi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio22" preload="none" src="https://whmsonic.radio.gov.pk:8066/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Chitral</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio23" preload="none" src="https://whmsonic.radio.gov.pk:8022/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Faisalabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio24" preload="none" src="https://whmsonic.radio.gov.pk:7022/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Karachi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio25" preload="none" src="https://whmsonic.radio.gov.pk:8088/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio26" preload="none" src="https://whmsonic.radio.gov.pk:8028/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Mianwali</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio27" preload="none" src="https://whmsonic.radio.gov.pk:8032/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Multan</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio28" preload="none" src="https://whmsonic.radio.gov.pk:8036/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">FM 93 Rawalpindi</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio29" preload="none" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGPu7EAAYqZ0ars2sgeryA"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm...</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio30" preload="none" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm...</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio31" preload="none" src="https://s33.myradiostream.com:13872/listen.m4a"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">fm.92</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio32" preload="none" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Fm.94.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio35" preload="none" src="https://server.mediacast4u.stream/8002/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Hum FM 106.2</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio36" preload="none" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">ILM Radio Renala FM 92</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio37" preload="none" src="https://cdn.voscast.com/resources/?key=4e1e2d7ac97ea7ad9493c529df2ab16c&amp;c=wmp"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Insaf Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio39" preload="none" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Love-Islam-Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio40" preload="none" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Mera FM 107.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio41" preload="none" src="https://samaalhr107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Mera FM 107.4 Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio42" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Multan MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio45" preload="none" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Mirpur</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio46" preload="none" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio One FM 91</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio49" preload="none" src="https://whmsonic.radio.gov.pk:8042/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Hyderabad MW 1008 KHz</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio50" preload="none" src="https://whmsonic.radio.gov.pk:7003/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Islamabad</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio51" preload="none" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Lahore</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio52" preload="none" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Lahore News and Current Affair AM 1332 KHZ</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio53" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Multan</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio54" preload="none" src="https://whmsonic.radio.gov.pk:8034/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Multan MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio55" preload="none" src="https://whmsonic.radio.gov.pk:8072/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Peshawar MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio56" preload="none" src="https://whmsonic.radio.gov.pk:8060/relay"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan Quetta MW</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio57" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan World Service</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio58" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Radio Pakistan WS</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio59" preload="none" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Samaa FM 107.4</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio60" preload="none" src="https://s97.radiolize.com:8040/radio.mp3"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">Shopen Anime Radio</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio61" preload="none" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</td>
-          <td></td>
         </tr>
         <tr>
           <td><audio id="audio63" preload="none" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
           <td class="station-name">পাকিস্তান</td>
-          <td></td>
         </tr>
         <!-- Additional stations discovered via StreamURL.link -->
         <tr>
@@ -461,6 +418,12 @@ document.addEventListener('DOMContentLoaded', function() {
     audio.preload = 'none';
     const button = audio.nextElementSibling;
     if (!button || !button.classList.contains('play-btn')) return;
+
+    // initialize button with label and hidden spinner
+    button.innerHTML = '<span class="label">Play</span><span class="spinner" aria-hidden="true"></span>';
+    const btnWidth = button.offsetWidth;
+    button.style.width = btnWidth + 'px';
+
     button.addEventListener('click', function() {
       // pause all other audio streams and reset their buttons
       players.forEach(function(other) {
@@ -468,27 +431,33 @@ document.addEventListener('DOMContentLoaded', function() {
           other.pause();
           const otherBtn = other.nextElementSibling;
           if (otherBtn && otherBtn.classList.contains('play-btn')) {
-            otherBtn.textContent = 'Play';
+            otherBtn.classList.remove('loading');
+            otherBtn.disabled = false;
+            const otherLabel = otherBtn.querySelector('.label');
+            if (otherLabel) otherLabel.textContent = 'Play';
           }
         }
       });
       // toggle play/pause on selected audio with loading indicator
       if (audio.paused) {
         // show loading state while the network request is in progress
-        button.textContent = 'Loading...';
+        button.classList.add('loading');
         button.disabled = true;
         const playPromise = audio.play();
         if (playPromise !== undefined) {
           playPromise.catch(function(err) {
             // handle autoplay restrictions or other errors
             button.disabled = false;
-            button.textContent = 'Play';
+            button.classList.remove('loading');
+            const label = button.querySelector('.label');
+            if (label) label.textContent = 'Play';
             console.error(err);
           });
         }
       } else {
         audio.pause();
-        button.textContent = 'Play';
+        const label = button.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // when the audio starts playing, update the button text to Stop
@@ -496,7 +465,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Stop';
       }
     });
     // when enough data has been downloaded to begin playing, update the button (canplay is often fired before playing)
@@ -504,7 +475,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
     // also handle canplaythrough (buffered enough to play through to end without stalling)
@@ -512,7 +485,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = audio.paused ? 'Play' : 'Stop';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = audio.paused ? 'Play' : 'Stop';
       }
     });
     // when audio is waiting/buffering, show Loading
@@ -520,7 +495,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = true;
-        btn.textContent = 'Loading...';
+        btn.classList.add('loading');
       }
     });
     // when the audio ends, reset button label
@@ -528,7 +503,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         btn.disabled = false;
-        btn.textContent = 'Play';
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) label.textContent = 'Play';
       }
     });
     // if paused by user, update label
@@ -538,7 +515,9 @@ document.addEventListener('DOMContentLoaded', function() {
         // if pause not due to ended event, show Play
         if (!audio.ended) {
           btn.disabled = false;
-          btn.textContent = 'Play';
+          btn.classList.remove('loading');
+          const label = btn.querySelector('.label');
+          if (label) label.textContent = 'Play';
         }
       }
     });
@@ -547,10 +526,14 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = audio.nextElementSibling;
       if (btn && btn.classList.contains('play-btn')) {
         // briefly show an error message before resetting to Play
-        btn.textContent = 'Unavailable';
-        setTimeout(function() {
-          btn.textContent = 'Play';
-        }, 4000);
+        btn.classList.remove('loading');
+        const label = btn.querySelector('.label');
+        if (label) {
+          label.textContent = 'Unavailable';
+          setTimeout(function() {
+            label.textContent = 'Play';
+          }, 4000);
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- show animated spinner for radio play button loading state
- keep play button width fixed and align radio page header with site navigation
- remove unused notes column from radio listings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb01020548320a5bfa0ea17318dd7