### PR TITLE
feat: animate mobile navigation

### DIFF
--- a/pakstream/about.html
+++ b/pakstream/about.html
@@ -54,5 +54,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/contact.html
+++ b/pakstream/contact.html
@@ -53,5 +53,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -1,5 +1,9 @@
 
 /* Global styles for PakStream */
+body {
+  overflow-x: hidden;
+}
+
 /* Header and Navigation Bar with Hamburger Support */
 header {
   display: flex;
@@ -140,15 +144,22 @@ footer {
   }
 
   nav {
-    width: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 250px;
+    background-color: #006400;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    padding-top: 60px;
+    z-index: 1001;
   }
 
   nav ul {
-    display: none;
     flex-direction: column;
-    background-color: #006400;
-    padding: 10px 0;
-    width: 100%;
+    margin: 0;
+    padding: 0;
   }
 
   nav a {
@@ -160,8 +171,8 @@ footer {
     background-color: #004d00;
   }
 
-  #nav-toggle:checked ~ nav ul {
-    display: flex;
+  #nav-toggle:checked ~ nav {
+    transform: translateX(0);
   }
 
   h1 {

--- a/pakstream/index.html
+++ b/pakstream/index.html
@@ -67,5 +67,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/js/menu.js
+++ b/pakstream/js/menu.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var navToggle = document.getElementById('nav-toggle');
+  var nav = document.querySelector('nav');
+  var label = document.querySelector('.nav-toggle-label');
+  if (!navToggle || !nav || !label) return;
+
+  navToggle.addEventListener('change', function () {
+    if (navToggle.checked) {
+      history.pushState({ menuOpen: true }, '');
+    } else if (history.state && history.state.menuOpen) {
+      history.back();
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    if (navToggle.checked && !nav.contains(e.target) && !label.contains(e.target)) {
+      navToggle.checked = false;
+    }
+  });
+
+  window.addEventListener('popstate', function () {
+    if (navToggle.checked) {
+      navToggle.checked = false;
+    }
+  });
+});

--- a/pakstream/privacy.html
+++ b/pakstream/privacy.html
@@ -55,5 +55,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -509,6 +509,7 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
   </script>
+  <script src="js/menu.js"></script>
 </body>
 </html>
 

--- a/pakstream/shop.html
+++ b/pakstream/shop.html
@@ -43,5 +43,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/terms.html
+++ b/pakstream/terms.html
@@ -57,5 +57,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -245,5 +245,6 @@
       btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
     }
   </script>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/tweets.html
+++ b/pakstream/tweets.html
@@ -48,5 +48,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
+  <script src="js/menu.js"></script>
 </body>
 </html>

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -228,5 +228,6 @@
     handleChannelClick(cards[0]);
   }
 </script>
+  <script src="js/menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add body overflow to hide horizontal scroll
- animate mobile menu with slide-in transform
- close mobile menu when clicking outside or using back button

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ebf32c8e8832092ccda49bdaf4f0a