### PR TITLE
Add sliding channel list menu for TV and YouTube pages

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -288,22 +288,25 @@ footer {
     flex-direction: column;
   }
   .youtube-section .channel-list {
-    display: none;
-    max-width: 100%;
-    height: auto;
     order: 2;
     position: fixed;
     top: 0;
     left: 0;
-    right: 0;
     bottom: 0;
+    width: 80%;
+    max-width: 280px;
     background: #fff;
     z-index: 1500;
     padding: 20px;
     overflow-y: auto;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
   }
   .youtube-section .channel-list.open {
-    display: block;
+    transform: translateX(0);
+    pointer-events: auto;
   }
   .youtube-section .video-section {
     order: 1;

--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -242,6 +242,15 @@
       list.classList.toggle('open');
       btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
     }
+
+    document.addEventListener('click', function(e) {
+      const list = document.querySelector('.channel-list');
+      const btn = document.getElementById('toggle-channels');
+      if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
+        list.classList.remove('open');
+        btn.textContent = 'Channels';
+      }
+    });
   </script>
   <script src="js/menu.js"></script>
 </body>

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -210,6 +210,15 @@
     btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
   }
 
+  document.addEventListener('click', function(e) {
+    const list = document.querySelector('.channel-list');
+    const btn = document.getElementById('toggle-channels');
+    if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
+      list.classList.remove('open');
+      btn.textContent = 'Channels';
+    }
+  });
+
   // Read anchor from URL
   const urlParams = new URLSearchParams(window.location.search);
   const anchorKey = urlParams.get('newsanchor');


### PR DESCRIPTION
## Summary
- Make channel lists slide in from the left on small screens
- Close channel list when clicking outside the panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f13e713308320a6180a4498dbe1d4