### PR TITLE
Auto-play deep-linked radio stations

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -38,7 +38,7 @@
     <h2>Online Pakistani Radio Stations</h2>
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
-      <audio id="radio-player" controls></audio>
+      <audio id="radio-player" controls autoplay></audio>
       <button id="favorite-btn" disabled>Add Favorite</button>
     </div>
     <table>
@@ -414,7 +414,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function loadStation(audio, name) {
     mainPlayer.src = audio.src;
-    mainPlayer.play();
+    mainPlayer.load();
+    const playPromise = mainPlayer.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {
+        mainPlayer.autoplay = true;
+      });
+    }
     currentLabel.textContent = name;
     updateFavButton(audio.id);
     const newUrl = `${window.location.pathname}?station=${audio.id}`;

--- a/radio.html
+++ b/radio.html
@@ -36,7 +36,7 @@
     <h2>Online Pakistani Radio Stations</h2>
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
-      <audio id="radio-player" controls></audio>
+      <audio id="radio-player" controls autoplay></audio>
       <button id="favorite-btn" disabled>Add Favorite</button>
     </div>
     <table>
@@ -413,7 +413,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function loadStation(audio, name) {
     mainPlayer.src = audio.src;
-    mainPlayer.play();
+    mainPlayer.load();
+    const playPromise = mainPlayer.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {
+        mainPlayer.autoplay = true;
+      });
+    }
     currentLabel.textContent = name;
     updateFavButton(audio.id);
     const newUrl = `${window.location.pathname}?station=${audio.id}`;


### PR DESCRIPTION
## Summary
- enable autoplay on main radio player
- trigger playback when a station is specified via query parameters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f317aa1cc8320a0295881c612e86d