### PR TITLE
Prevent page reload when switching radio stations

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -450,9 +450,13 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   buttons.forEach(btn => {
+    btn.setAttribute('type', 'button');
     const audio = btn.previousElementSibling;
     const name = btn.closest('tr').querySelector('.station-name').textContent;
-    btn.addEventListener('click', () => loadStation(audio, name));
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      loadStation(audio, name);
+    });
   });
 
   favBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure playing another station doesn't reload radio.html by giving play buttons `type="button"` and preventing default clicks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f36e9c94c8320b5b11e8d81bda989