### PR TITLE
Move favorite control to station rows

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -403,17 +403,16 @@ footer {
   margin: 0 auto 10px;
 }
 
-#favorite-btn {
-  padding: 6px 12px;
-  font-size: 0.9em;
-  cursor: pointer;
-  background-color: #ffcc00;
+.favorite-btn {
+  background: none;
   border: none;
-  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1.2em;
+  margin-right: 5px;
 }
 
-#favorite-btn.favorited {
-  background-color: #ffa000;
+.favorite-btn.favorited {
+  color: goldenrod;
 }
 
 .radio-list tr.favorite {

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -415,6 +415,11 @@ footer {
   color: goldenrod;
 }
 
+#player-container .controls {
+  display: flex;
+  align-items: center;
+}
+
 .radio-list tr.favorite {
   background-color: #fff8e1;
 }

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -39,7 +39,6 @@
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
       <audio id="radio-player" controls autoplay></audio>
-      <button id="favorite-btn" disabled>Add Favorite</button>
     </div>
     <table>
       <tbody>
@@ -384,10 +383,10 @@
 // Central radio player with favorites and deep links
 document.addEventListener('DOMContentLoaded', function() {
   const mainPlayer = document.getElementById('radio-player');
-  const favBtn = document.getElementById('favorite-btn');
   const currentLabel = document.getElementById('current-station');
-  const buttons = Array.from(document.querySelectorAll('.play-btn'));
+  const playButtons = Array.from(document.querySelectorAll('.play-btn'));
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
+  const favButtons = [];
   let currentBtn = null;
   let pendingBtn = null;
 
@@ -413,27 +412,16 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function updateFavoritesUI() {
-    buttons.forEach(btn => {
-      const audio = btn.previousElementSibling;
-      const row = btn.closest('tr');
-      if (!audio || !row) return;
-      row.classList.toggle('favorite', favorites.includes(audio.id));
+    favButtons.forEach(favBtn => {
+      const id = favBtn.dataset.id;
+      const row = favBtn.closest('tr');
+      if (!id || !row) return;
+      const isFav = favorites.includes(id);
+      favBtn.textContent = isFav ? '★' : '☆';
+      favBtn.classList.toggle('favorited', isFav);
+      row.classList.toggle('favorite', isFav);
     });
     reorderFavorites();
-  }
-
-  function updateFavButton(id) {
-    if (!id) {
-      favBtn.disabled = true;
-      favBtn.textContent = 'Add Favorite';
-      favBtn.classList.remove('favorited');
-      return;
-    }
-    favBtn.disabled = false;
-    favBtn.dataset.id = id;
-    const isFav = favorites.includes(id);
-    favBtn.textContent = isFav ? 'Remove Favorite' : 'Add Favorite';
-    favBtn.classList.toggle('favorited', isFav);
   }
 
   function resetButton(btn) {
@@ -448,7 +436,6 @@ document.addEventListener('DOMContentLoaded', function() {
     mainPlayer.removeAttribute('src');
     mainPlayer.load();
     currentLabel.textContent = 'Select a station';
-    updateFavButton(null);
     history.replaceState(null, '', window.location.pathname);
     resetButton(currentBtn);
     currentBtn = null;
@@ -467,16 +454,24 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
     currentLabel.textContent = name;
-    updateFavButton(audio.id);
     const newUrl = `${window.location.pathname}?station=${audio.id}`;
     history.replaceState(null, '', newUrl);
   }
 
-  buttons.forEach(btn => {
-    btn.setAttribute('type', 'button');
+  playButtons.forEach(btn => {
     const audio = btn.previousElementSibling;
     const name = btn.closest('tr').querySelector('.station-name').textContent;
     const text = btn.textContent.trim();
+
+    const fav = document.createElement('button');
+    fav.className = 'favorite-btn';
+    fav.type = 'button';
+    fav.dataset.id = audio.id;
+    fav.textContent = '☆';
+    btn.parentNode.insertBefore(fav, btn);
+    favButtons.push(fav);
+
+    btn.setAttribute('type', 'button');
     btn.innerHTML = `<span class="label">${text}</span><span class="spinner"></span>`;
     btn.addEventListener('click', (e) => {
       e.preventDefault();
@@ -486,6 +481,16 @@ document.addEventListener('DOMContentLoaded', function() {
         resetButton(currentBtn);
         loadStation(audio, name, btn);
       }
+    });
+
+    fav.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = fav.dataset.id;
+      const idx = favorites.indexOf(id);
+      if (idx >= 0) favorites.splice(idx, 1);
+      else favorites.push(id);
+      localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+      updateFavoritesUI();
     });
   });
 
@@ -510,17 +515,6 @@ document.addEventListener('DOMContentLoaded', function() {
     pendingBtn = null;
   });
 
-  favBtn.addEventListener('click', () => {
-    const id = favBtn.dataset.id;
-    if (!id) return;
-    const idx = favorites.indexOf(id);
-    if (idx >= 0) favorites.splice(idx, 1);
-    else favorites.push(id);
-    localStorage.setItem('radioFavorites', JSON.stringify(favorites));
-    updateFavButton(id);
-    updateFavoritesUI();
-  });
-
   updateFavoritesUI();
 
   const params = new URLSearchParams(window.location.search);
@@ -529,7 +523,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const audio = document.getElementById(initial);
     if (audio) {
       const name = audio.closest('tr').querySelector('.station-name').textContent;
-      const btn = audio.nextElementSibling;
+      const btn = audio.parentElement.querySelector('.play-btn');
       resetButton(currentBtn);
       loadStation(audio, name, btn);
     }

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -38,7 +38,10 @@
     <h2>Online Pakistani Radio Stations</h2>
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
-      <audio id="radio-player" controls autoplay></audio>
+      <div class="controls">
+        <button id="favorite-btn" class="favorite-btn" type="button" aria-label="Toggle favorite" disabled>☆</button>
+        <audio id="radio-player" controls autoplay></audio>
+      </div>
     </div>
     <table>
       <tbody>
@@ -385,43 +388,30 @@ document.addEventListener('DOMContentLoaded', function() {
   const mainPlayer = document.getElementById('radio-player');
   const currentLabel = document.getElementById('current-station');
   const playButtons = Array.from(document.querySelectorAll('.play-btn'));
+  const favBtn = document.getElementById('favorite-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
-  const favButtons = [];
   let currentBtn = null;
   let pendingBtn = null;
-
-  function reorderFavorites() {
-    const tbody = document.querySelector('table tbody');
-    const rows = Array.from(tbody.querySelectorAll('tr')).slice(1);
-    const favRows = [];
-    const otherRows = [];
-    rows.forEach(row => {
-      const id = row.querySelector('audio')?.id;
-      if (id && favorites.includes(id)) {
-        favRows.push(row);
-      } else {
-        otherRows.push(row);
-      }
-    });
-    favRows.sort((a, b) => {
-      const aId = a.querySelector('audio')?.id;
-      const bId = b.querySelector('audio')?.id;
-      return favorites.indexOf(aId) - favorites.indexOf(bId);
-    });
-    [...favRows, ...otherRows].forEach(row => tbody.appendChild(row));
-  }
+  let currentAudio = null;
 
   function updateFavoritesUI() {
-    favButtons.forEach(favBtn => {
-      const id = favBtn.dataset.id;
-      const row = favBtn.closest('tr');
-      if (!id || !row) return;
+    document.querySelectorAll('table tbody tr').forEach(row => {
+      const audio = row.querySelector('audio');
+      const id = audio?.id;
+      if (!id) return;
       const isFav = favorites.includes(id);
-      favBtn.textContent = isFav ? '★' : '☆';
-      favBtn.classList.toggle('favorited', isFav);
       row.classList.toggle('favorite', isFav);
     });
-    reorderFavorites();
+    if (currentAudio) {
+      const isFav = favorites.includes(currentAudio.id);
+      favBtn.textContent = isFav ? '★' : '☆';
+      favBtn.classList.toggle('favorited', isFav);
+      favBtn.disabled = false;
+    } else {
+      favBtn.textContent = '☆';
+      favBtn.classList.remove('favorited');
+      favBtn.disabled = true;
+    }
   }
 
   function resetButton(btn) {
@@ -440,6 +430,8 @@ document.addEventListener('DOMContentLoaded', function() {
     resetButton(currentBtn);
     currentBtn = null;
     pendingBtn = null;
+    currentAudio = null;
+    updateFavoritesUI();
   }
 
   function loadStation(audio, name, btn) {
@@ -453,24 +445,17 @@ document.addEventListener('DOMContentLoaded', function() {
         mainPlayer.autoplay = true;
       });
     }
+    currentAudio = audio;
     currentLabel.textContent = name;
     const newUrl = `${window.location.pathname}?station=${audio.id}`;
     history.replaceState(null, '', newUrl);
+    updateFavoritesUI();
   }
 
   playButtons.forEach(btn => {
     const audio = btn.previousElementSibling;
     const name = btn.closest('tr').querySelector('.station-name').textContent;
     const text = btn.textContent.trim();
-
-    const fav = document.createElement('button');
-    fav.className = 'favorite-btn';
-    fav.type = 'button';
-    fav.dataset.id = audio.id;
-    fav.textContent = '☆';
-    btn.parentNode.insertBefore(fav, btn);
-    favButtons.push(fav);
-
     btn.setAttribute('type', 'button');
     btn.innerHTML = `<span class="label">${text}</span><span class="spinner"></span>`;
     btn.addEventListener('click', (e) => {
@@ -482,16 +467,16 @@ document.addEventListener('DOMContentLoaded', function() {
         loadStation(audio, name, btn);
       }
     });
+  });
 
-    fav.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const id = fav.dataset.id;
-      const idx = favorites.indexOf(id);
-      if (idx >= 0) favorites.splice(idx, 1);
-      else favorites.push(id);
-      localStorage.setItem('radioFavorites', JSON.stringify(favorites));
-      updateFavoritesUI();
-    });
+  favBtn.addEventListener('click', () => {
+    if (!currentAudio) return;
+    const id = currentAudio.id;
+    const idx = favorites.indexOf(id);
+    if (idx >= 0) favorites.splice(idx, 1);
+    else favorites.push(id);
+    localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+    updateFavoritesUI();
   });
 
   mainPlayer.addEventListener('playing', () => {
@@ -513,6 +498,8 @@ document.addEventListener('DOMContentLoaded', function() {
     resetButton(pendingBtn || currentBtn);
     currentBtn = null;
     pendingBtn = null;
+    currentAudio = null;
+    updateFavoritesUI();
   });
 
   updateFavoritesUI();


### PR DESCRIPTION
## Summary
- attach favorite icon to each radio row and manage favorites per station
- style new favorite button and remove standalone control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f469aa0288320bd30b535c6a9ad29