### PR TITLE
Add navigation for favorite radio stations

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -403,7 +403,7 @@ footer {
   margin: 0 auto 10px;
 }
 
-.favorite-btn {
+.favorite-btn, .fav-nav-btn {
   background: none;
   border: none;
   cursor: pointer;

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -39,7 +39,9 @@
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
       <div class="controls">
+        <button id="prev-fav-btn" class="fav-nav-btn" type="button" aria-label="Previous favorite" disabled>&lt;</button>
         <button id="favorite-btn" class="favorite-btn" type="button" aria-label="Toggle favorite" disabled>☆</button>
+        <button id="next-fav-btn" class="fav-nav-btn" type="button" aria-label="Next favorite" disabled>&gt;</button>
         <audio id="radio-player" controls autoplay></audio>
       </div>
     </div>
@@ -389,6 +391,8 @@ document.addEventListener('DOMContentLoaded', function() {
   const currentLabel = document.getElementById('current-station');
   const playButtons = Array.from(document.querySelectorAll('.play-btn'));
   const favBtn = document.getElementById('favorite-btn');
+  const prevFavBtn = document.getElementById('prev-fav-btn');
+  const nextFavBtn = document.getElementById('next-fav-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
   let currentBtn = null;
   let pendingBtn = null;
@@ -412,6 +416,8 @@ document.addEventListener('DOMContentLoaded', function() {
       favBtn.classList.remove('favorited');
       favBtn.disabled = true;
     }
+    const hasFavorites = favorites.length > 0;
+    prevFavBtn.disabled = nextFavBtn.disabled = !hasFavorites;
   }
 
   function resetButton(btn) {
@@ -478,6 +484,28 @@ document.addEventListener('DOMContentLoaded', function() {
     localStorage.setItem('radioFavorites', JSON.stringify(favorites));
     updateFavoritesUI();
   });
+
+  function playFavorite(offset) {
+    if (favorites.length === 0) return;
+    const currentId = currentAudio ? currentAudio.id : null;
+    let idx = currentId ? favorites.indexOf(currentId) : -1;
+    if (idx === -1) {
+      idx = offset > 0 ? 0 : favorites.length - 1;
+    } else {
+      idx = (idx + offset + favorites.length) % favorites.length;
+    }
+    const nextId = favorites[idx];
+    const audio = document.getElementById(nextId);
+    if (audio) {
+      const name = audio.closest('tr').querySelector('.station-name').textContent;
+      const btn = audio.parentElement.querySelector('.play-btn');
+      resetButton(currentBtn);
+      loadStation(audio, name, btn);
+    }
+  }
+
+  prevFavBtn.addEventListener('click', () => playFavorite(-1));
+  nextFavBtn.addEventListener('click', () => playFavorite(1));
 
   mainPlayer.addEventListener('playing', () => {
     if (pendingBtn) {


### PR DESCRIPTION
## Summary
- add Previous and Next favorite buttons in radio player UI
- enable navigating between saved favorite stations with new controls
- share styling for favorite navigation buttons

## Testing
- `jekyll build >/tmp/jekyll.log && tail -n 20 /tmp/jekyll.log`
- `npm test >/tmp/npm-test.log && tail -n 20 /tmp/npm-test.log`

------
https://chatgpt.com/codex/tasks/task_e_688f4a008708832089d7b8fa6eeaf0de