### PR TITLE
Enhance radio player control icons

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -407,8 +407,13 @@ footer {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 1.2em;
-  margin-right: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 32px;
+  font-size: 24px;
+  line-height: 1;
 }
 
 .favorite-btn.favorited {
@@ -418,6 +423,7 @@ footer {
 #player-container .controls {
   display: flex;
   align-items: center;
+  gap: 10px;
 }
 
 .radio-list tr.favorite {

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -39,9 +39,9 @@
     <div id="player-container" class="radio-player">
       <h3 id="current-station">Select a station</h3>
       <div class="controls">
-        <button id="prev-fav-btn" class="fav-nav-btn" type="button" aria-label="Previous favorite" disabled>&lt;</button>
+        <button id="prev-fav-btn" class="fav-nav-btn" type="button" aria-label="Previous favorite" disabled>&#9198;</button>
         <button id="favorite-btn" class="favorite-btn" type="button" aria-label="Toggle favorite" disabled>☆</button>
-        <button id="next-fav-btn" class="fav-nav-btn" type="button" aria-label="Next favorite" disabled>&gt;</button>
+        <button id="next-fav-btn" class="fav-nav-btn" type="button" aria-label="Next favorite" disabled>&#9197;</button>
         <audio id="radio-player" controls autoplay></audio>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Use track control icons for navigating favorite stations
- Standardize control button sizing and alignment for a cleaner layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5dcef128832093d30fc274d779bb