### PR TITLE
Ensure consistent YouTube player size

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -229,17 +229,7 @@ footer {
   padding-left: 20px;
 }
 
-.youtube-section .player-wrapper {
-  width: 100%;
-}
-
-.youtube-section .player-wrapper iframe {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  height: auto;
-  border: none;
-  display: block;
-}
+/* Player wrapper replaced by live-player for consistent sizing */
 
 .youtube-section .video-list {
   margin-top: 10px;
@@ -321,6 +311,8 @@ footer {
   width: 100%;
   aspect-ratio: 16 / 9;
   border: none;
+  height: auto;
+  display: block;
 }
 
 /* Styles specific to the radio list page */

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -63,7 +63,7 @@
     </div>
     <!-- Video display area: a player for the selected video and a list of recent videos -->
     <div class="video-section">
-      <div class="player-wrapper">
+      <div class="live-player">
         <iframe id="playerFrame" src="" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>


### PR DESCRIPTION
## Summary
- Reuse `live-player` wrapper on YouTube page so embedded videos keep the same dimensions as TV channels
- Tidy CSS by dropping `player-wrapper` styles and expanding `.live-player iframe` for consistent sizing

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688f697f29e08320ba5790bdca5f1354