### PR TITLE
Fix YouTube page player sizing

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -306,12 +306,16 @@ footer {
   }
 }
 
-/* Styles specific to the TV page */
-.live-player iframe {
+/* Consistent video player sizing across pages */
+.live-player {
   width: 100%;
   aspect-ratio: 16 / 9;
+}
+
+.live-player iframe {
+  width: 100%;
+  height: 100%;
   border: none;
-  height: auto;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- Ensure live-player wrappers define a 16:9 aspect ratio so embedded videos keep consistent dimensions across TV and YouTube pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6bf2d5808320965a46ca1d4643a0