### PR TITLE
refactor: centralize navigation bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,26 +9,7 @@
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="/index.html">Home</a></li>
-        <li><a href="/pakstream/youtube.html">YouTube</a></li>
-        <li><a href="/pakstream/tv.html">TV</a></li>
-        <li><a href="/pakstream/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/pakstream/about.html">About</a></li>
-        <li><a href="/pakstream/contact.html">Contact</a></li>
-        <li><a href="/pakstream/privacy.html">Privacy</a></li>
-        <li><a href="/pakstream/terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <main>
     {{ content }}
@@ -45,6 +26,6 @@
   <footer>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/pakstream/js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,33 +8,10 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="pakstream/css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <!-- Site header with responsive navigation -->
-  <header>
-    <!-- Hidden checkbox used for the mobile hamburger menu -->
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <!-- Logo/title -->
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <!-- Primary navigation links -->
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="pakstream/youtube.html">YouTube</a></li>
-        <li><a href="pakstream/tv.html">TV</a></li>
-        <li><a href="pakstream/radio.html">Radio</a></li>
-        <li><a href="blog.html">Blog</a></li>
-        <li><a href="pakstream/about.html">About</a></li>
-        <li><a href="pakstream/contact.html">Contact</a></li>
-        <li><a href="pakstream/privacy.html">Privacy</a></li>
-        <li><a href="pakstream/terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Hero section with image and tagline -->
   <div class="hero">
@@ -63,6 +40,6 @@
   <footer>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="pakstream/js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,20 @@
+<header>
+  <input type="checkbox" id="nav-toggle">
+  <label for="nav-toggle" class="nav-toggle-label">☰</label>
+  <div class="logo-title">
+    <h1>PakStream</h1>
+  </div>
+  <nav>
+    <ul>
+      <li><a href="/index.html">Home</a></li>
+      <li><a href="/pakstream/youtube.html">YouTube</a></li>
+      <li><a href="/pakstream/tv.html">TV</a></li>
+      <li><a href="/pakstream/radio.html">Radio</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="/pakstream/about.html">About</a></li>
+      <li><a href="/pakstream/contact.html">Contact</a></li>
+      <li><a href="/pakstream/privacy.html">Privacy</a></li>
+      <li><a href="/pakstream/terms.html">Terms</a></li>
+    </ul>
+  </nav>
+</header>

--- a/pakstream/about.html
+++ b/pakstream/about.html
@@ -8,30 +8,10 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <!-- Header with navigation -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- About section describing the mission of PakStream -->
   <section>
@@ -52,6 +32,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/contact.html
+++ b/pakstream/contact.html
@@ -8,30 +8,11 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
   <!-- Header with navigation -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Contact section with instructions to reach us -->
 <section>
@@ -51,6 +32,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/index.html
+++ b/pakstream/index.html
@@ -8,33 +8,10 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <!-- Site header with responsive navigation -->
-  <header>
-    <!-- Hidden checkbox used for the mobile hamburger menu -->
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <!-- Logo/title -->
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <!-- Primary navigation links -->
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Hero section with image and tagline -->
   <div class="hero">
@@ -63,6 +40,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/js/load-nav.js
+++ b/pakstream/js/load-nav.js
@@ -1,0 +1,13 @@
+(function() {
+  fetch('/nav.html')
+    .then(function(response) { return response.text(); })
+    .then(function(html) {
+      var placeholder = document.getElementById('nav-placeholder');
+      if (placeholder) {
+        placeholder.innerHTML = html;
+        var script = document.createElement('script');
+        script.src = '/pakstream/js/menu.js';
+        document.body.appendChild(script);
+      }
+    });
+})();

--- a/pakstream/privacy.html
+++ b/pakstream/privacy.html
@@ -8,30 +8,11 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
   <!-- Header with navigation -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Privacy policy content -->
 <section>
@@ -53,6 +34,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -8,31 +8,11 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="radio-list">
-  <!-- Header with navigation -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Radio station listing -->
   <section>
@@ -615,8 +595,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
   </script>
-  <script src="js/menu.js"></script>
-
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>
 

--- a/pakstream/terms.html
+++ b/pakstream/terms.html
@@ -8,30 +8,11 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
   <!-- Header with navigation -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- Terms and conditions content -->
 <section>
@@ -55,6 +36,6 @@
   <footer>
     <p>© 2025 PakStream.</p>
   </footer>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -5,31 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>PakStream – Live TV</title>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <header>
-    <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu">
-    <label for="nav-toggle" class="nav-toggle-label">
-      ☰ <span class="sr-only">Toggle Menu</span>
-    </label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
 
   <!-- TV Livestream section -->
@@ -252,6 +231,6 @@
       }
     });
   </script>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -8,30 +8,10 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>
-  <!-- Header with navigation.  The hamburger menu appears on small screens. -->
-  <header>
-    <input type="checkbox" id="nav-toggle">
-      <label for="nav-toggle" class="nav-toggle-label">☰ <span class="sr-only">Toggle Menu</span></label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="youtube.html">YouTube</a></li>
-        <li><a href="tv.html">TV</a></li>
-        <li><a href="radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="contact.html">Contact</a></li>
-        <li><a href="privacy.html">Privacy</a></li>
-        <li><a href="terms.html">Terms</a></li>
-      </ul>
-    </nav>
-  </header>
+  <div id="nav-placeholder"></div>
 
   <!-- YouTube section with channel list and video player -->
   <section class="youtube-section">
@@ -235,6 +215,6 @@
     handleChannelClick(cards[0]);
   }
 </script>
-  <script src="js/menu.js"></script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract navigation markup to standalone `nav.html`
- inject nav on each page with new `load-nav.js`
- update all pages and default layout to use shared navigation

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `jekyll build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c69da8c8320854b9fb37176bbf3