### PR TITLE
Apply Material Design styling across pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,19 +1,211 @@
-body {
-  font-family: Arial, sans-serif;
-  background: #f9f9f9;
-  color: #333;
-  padding: 20px;
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+
+:root {
+  --md-primary: #1E88E5;
+  --md-on-primary: #ffffff;
+  --md-surface: #ffffff;
+  --md-background: #f9f9f9;
+  --md-on-surface: #333333;
 }
 
-header {
-  margin-bottom: 20px;
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  padding: 0;
+  margin: 0;
+}
+
+/* Top app bar */
+.top-bar {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 56px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.logo-title h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  line-height: 56px;
+}
+
+.nav-toggle-label {
+  color: var(--md-on-primary);
+  font-size: 1.5rem;
+  margin-right: 16px;
+  cursor: pointer;
+}
+
+nav {
+  flex-grow: 1;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+nav li {
+  margin-right: 16px;
 }
 
 nav a {
-  margin-right: 10px;
+  color: var(--md-on-primary);
+  text-decoration: none;
+  font-weight: 500;
 }
 
-/* Post container */
+nav a:hover {
+  text-decoration: underline;
+}
+
+#nav-toggle {
+  display: none;
+}
+
+/* Generic sections */
+section {
+  background: var(--md-surface);
+  margin: 20px auto;
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  max-width: 960px;
+}
+
+.hero {
+  text-align: center;
+  padding: 40px 20px;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin: 20px auto;
+}
+
+.hero img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 16px;
+}
+
+/* Card-like elements */
+.channel-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.channel-card {
+  background: var(--md-surface);
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.channel-card:hover {
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}
+
+.channel-card.active {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.video-section {
+  margin-top: 16px;
+}
+
+.video-section iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
+}
+
+.video-list .video-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.video-list .video-item img {
+  width: 120px;
+  height: 67px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.video-list .video-item.active {
+  background: rgba(30,136,229,0.1);
+}
+
+/* Buttons */
+button,
+.channel-toggle,
+.play-btn {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.play-btn:hover {
+  background: #1565c0;
+}
+
+/* Radio player controls */
+.radio-player {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin-bottom: 16px;
+}
+
+.controls button {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 4px;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  text-align: left;
+}
+
+/* Post layout */
 .post-container {
   padding: 20px;
   max-width: 800px;
@@ -21,14 +213,19 @@ nav a {
   box-sizing: border-box;
 }
 
-/* Post title */
+.post {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
 .post h1 {
   font-size: 2em;
   margin-bottom: 10px;
   color: #263238;
 }
 
-/* Meta info and author */
 .post-meta,
 .post-author {
   color: #777;
@@ -36,7 +233,6 @@ nav a {
   margin-bottom: 8px;
 }
 
-/* Featured image */
 .post-featured-image {
   width: 100%;
   height: auto;
@@ -44,14 +240,12 @@ nav a {
   border-radius: 8px;
 }
 
-/* Post content */
 .post-content {
   line-height: 1.7;
   font-size: 1em;
   color: #333;
 }
 
-/* Social share section */
 .post-share {
   margin-top: 30px;
   font-size: 0.9em;
@@ -85,6 +279,25 @@ nav a {
 
   .post-featured-image {
     margin: 15px 0;
+  }
+
+  nav ul {
+    flex-direction: column;
+    display: none;
+    background: var(--md-primary);
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    padding: 16px;
+  }
+
+  #nav-toggle:checked ~ nav ul {
+    display: flex;
+  }
+
+  nav li {
+    margin: 8px 0;
   }
 }
 
@@ -120,4 +333,392 @@ nav a {
   to {
     transform: rotate(360deg);
   }
+}
+
+/* Utility page for nadraimage */
+.utility-page {
+  text-align: center;
+  padding: 2rem;
+}
+
+.utility-page video,
+.utility-page canvas,
+.utility-page img {
+  max-width: 100%;
+  border: 1px solid #ccc;
+  margin-top: 1rem;
+  border-radius: 4px;
+}
+
+.utility-page button {
+  margin: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 16px;
+  margin-top: 40px;
+  color: var(--md-on-surface);
+}
+
+.ad-container {
+  margin: 20px 0;
+  text-align: center;
+}
+body {
+  font-family: 'Roboto', sans-serif;
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  padding: 0;
+  margin: 0;
+}
+
+/* Top app bar */
+.top-bar {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 56px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.logo-title h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  line-height: 56px;
+}
+
+.nav-toggle-label {
+  color: var(--md-on-primary);
+  font-size: 1.5rem;
+  margin-right: 16px;
+  cursor: pointer;
+}
+
+nav {
+  flex-grow: 1;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+nav li {
+  margin-right: 16px;
+}
+
+nav a {
+  color: var(--md-on-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+#nav-toggle {
+  display: none;
+}
+
+/* Generic sections */
+section {
+  background: var(--md-surface);
+  margin: 20px auto;
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  max-width: 960px;
+}
+
+.hero {
+  text-align: center;
+  padding: 40px 20px;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin: 20px auto;
+}
+
+.hero img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 16px;
+}
+
+/* Card-like elements */
+.channel-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.channel-card {
+  background: var(--md-surface);
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.channel-card:hover {
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}
+
+.channel-card.active {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.video-section {
+  margin-top: 16px;
+}
+
+.video-section iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
+}
+
+.video-list .video-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.video-list .video-item img {
+  width: 120px;
+  height: 67px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.video-list .video-item.active {
+  background: rgba(30,136,229,0.1);
+}
+
+/* Buttons */
+button,
+.channel-toggle,
+.play-btn {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.play-btn:hover {
+  background: #1565c0;
+}
+
+/* Radio player controls */
+.radio-player {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin-bottom: 16px;
+}
+
+.controls button {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 4px;
+}
+
+/* Tables */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  text-align: left;
+}
+
+/* Post layout */
+.post-container {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+  box-sizing: border-box;
+}
+
+.post {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.post h1 {
+  font-size: 2em;
+  margin-bottom: 10px;
+  color: #263238;
+}
+
+.post-meta,
+.post-author {
+  color: #777;
+  font-size: 0.9em;
+  margin-bottom: 8px;
+}
+
+.post-featured-image {
+  width: 100%;
+  height: auto;
+  margin: 20px 0;
+  border-radius: 8px;
+}
+
+.post-content {
+  line-height: 1.7;
+  font-size: 1em;
+  color: #333;
+}
+
+.post-share {
+  margin-top: 30px;
+  font-size: 0.9em;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+}
+
+.post-share a {
+  text-decoration: none;
+  margin-right: 10px;
+  color: #1E88E5;
+}
+
+.post-share a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .post h1 {
+    font-size: 1.5em;
+  }
+
+  .post-container {
+    padding: 15px;
+  }
+
+  .post-content {
+    font-size: 0.95em;
+  }
+
+  .post-featured-image {
+    margin: 15px 0;
+  }
+
+  nav ul {
+    flex-direction: column;
+    display: none;
+    background: var(--md-primary);
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    padding: 16px;
+  }
+
+  #nav-toggle:checked ~ nav ul {
+    display: flex;
+  }
+
+  nav li {
+    margin: 8px 0;
+  }
+}
+
+/* Spinner styles for radio play buttons */
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 60px;
+}
+
+.play-btn .spinner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Utility page for nadraimage */
+.utility-page {
+  text-align: center;
+  padding: 2rem;
+}
+
+.utility-page video,
+.utility-page canvas,
+.utility-page img {
+  max-width: 100%;
+  border: 1px solid #ccc;
+  margin-top: 1rem;
+  border-radius: 4px;
+}
+
+.utility-page button {
+  margin: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 16px;
+  margin-top: 40px;
+  color: var(--md-on-surface);
+}
+
+.ad-container {
+  margin: 20px 0;
+  text-align: center;
 }

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -3,14 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Passport Photo Resizer new</title>
-  <style>
-    body { font-family: sans-serif; text-align: center; padding: 2rem; background: #f2f2f2; }
-    video, canvas, img { max-width: 100%; border: 1px solid #ccc; margin-top: 1rem; }
-    button { margin: 1rem; padding: 0.6rem 1.2rem; font-size: 1rem; cursor: pointer; }
-  </style>
+  <title>Passport Photo Resizer</title>
+  <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
-<body>
+<body class="utility-page">
+  <div id="nav-placeholder"></div>
   <h1>Passport Photo Resizer (35x45mm)</h1>
   <video id="video" autoplay playsinline width="400"></video><br>
   <button id="captureBtn">📸 Capture</button>
@@ -83,5 +80,6 @@
       img.src = preview.src;
     };
   </script>
+  <script src="/pakstream/js/load-nav.js"></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -1,11 +1,11 @@
-<header>
+<header class="top-bar">
   <input type="checkbox" id="nav-toggle">
   <label for="nav-toggle" class="nav-toggle-label">☰</label>
   <div class="logo-title">
     <h1>PakStream</h1>
   </div>
   <nav>
-    <ul>
+    <ul class="nav-links">
       <li><a href="/index.html">Home</a></li>
       <li><a href="/pakstream/youtube.html">YouTube</a></li>
       <li><a href="/pakstream/tv.html">TV</a></li>

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -1,449 +1,224 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
-/* Global styles for PakStream */
-body {
-  overflow-x: hidden;
+:root {
+  --md-primary: #006400;
+  --md-on-primary: #ffffff;
+  --md-surface: #ffffff;
+  --md-background: #f5f5f5;
+  --md-on-surface: #333333;
 }
 
-/* Header and Navigation Bar with Hamburger Support */
-header {
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  padding: 0;
+  margin: 0;
+}
+
+/* Top app bar */
+.top-bar {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-  padding: 10px 20px;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
+  padding: 0 16px;
+  height: 56px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
-header h1 {
+.logo-title h1 {
+  font-size: 1.25rem;
   margin: 0;
-  font-size: 24px;
+  line-height: 56px;
   color: #cc0000;
 }
 
-/* Visually hide checkbox but keep it focusable for accessibility */
-#nav-toggle {
-  position: absolute;
-  opacity: 0;
-}
-
-/* Hamburger icon */
 .nav-toggle-label {
-  display: none;
-  font-size: 28px;
-  color: #cc0000;
-  padding: 10px;
+  color: var(--md-on-primary);
+  font-size: 1.5rem;
+  margin-right: 16px;
   cursor: pointer;
 }
 
-/* Desktop navigation menu */
+nav {
+  flex-grow: 1;
+}
+
 nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
-  gap: 20px;
+  flex-wrap: wrap;
 }
 
 nav li {
-  margin: 0;
+  margin-right: 16px;
 }
 
 nav a {
+  color: var(--md-on-primary);
   text-decoration: none;
-  color: #333;
   font-weight: 500;
-  padding: 8px 12px;
-  display: block;
-  border-radius: 4px;
 }
 
 nav a:hover {
-  color: #cc0000;
+  text-decoration: underline;
 }
 
-/* Screen-reader-only utility */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+#nav-toggle {
+  display: none;
+}
+
+/* Generic sections */
+section {
+  background: var(--md-surface);
+  margin: 20px auto;
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  max-width: 960px;
 }
 
 .hero {
   text-align: center;
   padding: 40px 20px;
-  background-color: #eef5f0;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin: 20px auto;
 }
 
 .hero img {
   max-width: 100%;
   height: auto;
-  border-radius: 8px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
-section {
-  margin: 20px auto;
-  max-width: 960px;
-  padding: 20px;
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+/* Card-like elements */
+.channel-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-h2, h3 {
-  color: #006400;
+.channel-card {
+  background: var(--md-surface);
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
 }
 
+.channel-card:hover {
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}
+
+.channel-card.active {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.video-section {
+  margin-top: 16px;
+}
+
+.video-section iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
+}
+
+.video-list .video-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.video-list .video-item img {
+  width: 120px;
+  height: 67px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.video-list .video-item.active {
+  background: rgba(0,100,0,0.1);
+}
+
+/* Buttons */
+button,
+.channel-toggle,
+.play-btn {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.play-btn:hover {
+  background: #004d00;
+}
+
+/* Radio player controls */
+.radio-player {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin-bottom: 16px;
+}
+
+.controls button {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 4px;
+}
+
+/* Tables */
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 20px;
 }
 
 th, td {
-  border: 1px solid #ccc;
   padding: 8px;
-  text-align: left;
+  border-bottom: 1px solid #ddd;
 }
 
 th {
-  background-color: #f2f2f2;
+  text-align: left;
 }
 
-.ad-container {
-  margin: 20px auto;
-  text-align: center;
-  max-width: 960px;
-}
-
-footer {
-  background-color: #006400;
-  color: #fff;
-  text-align: center;
-  padding: 10px;
-  margin-top: 40px;
-}
-
-/* Responsive adjustments for mobile devices */
-@media (max-width: 768px) {
-  header {
-    flex-wrap: wrap;
-    align-items: flex-start;
-  }
-
-  .nav-toggle-label {
-    display: block;
-  }
-
-  nav {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 250px;
-    background-color: #006400;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-    padding-top: 60px;
-    z-index: 1001;
-  }
-
-  nav ul {
-    flex-direction: column;
-    margin: 0;
-    padding: 0;
-  }
-
-  nav a {
-    padding: 12px 20px;
-    color: white;
-  }
-
-  nav a:hover {
-    background-color: #004d00;
-  }
-
-  #nav-toggle:checked ~ nav {
-    transform: translateX(0);
-  }
-
-  h1 {
-    flex: 1 1 100%;
-    text-align: center;
-  }
-}
-
-/* Styles specific to YouTube page */
-.youtube-section {
-  display: flex;
-  gap: 20px;
-  padding: 20px;
-}
-
-.channel-toggle {
-  display: none;
-  align-self: flex-start;
-  margin-bottom: 10px;
-  padding: 8px 12px;
-}
-
-.youtube-section .channel-list {
-  flex: 1;
-  max-width: 280px;
-  overflow-y: auto;
-  height: calc(100vh - 100px);
-}
-
-.youtube-section .channel-card {
-  background: #fff;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 12px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.youtube-section .channel-card:hover {
-  background: #f0f0f0;
-}
-
-.youtube-section .channel-card.active {
-  background: #e8e8e8;
-  font-weight: bold;
-}
-
-.youtube-section .video-section {
-  flex: 2;
-  display: flex;
-  flex-direction: column;
-  padding-left: 20px;
-}
-
-/* Player wrapper replaced by live-player for consistent sizing */
-
-.youtube-section .video-list {
-  margin-top: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  overflow-y: auto;
-  max-height: 400px;
-}
-
-.youtube-section .video-item {
-  display: flex;
-  gap: 8px;
-  padding: 6px;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  align-items: center;
-}
-
-.youtube-section .video-item:hover {
-  background: #f0f0f0;
-}
-
-.youtube-section .video-item.active {
-  background: #e8e8e8;
-}
-
-.youtube-section .video-item img {
-  width: 120px;
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  border-radius: 4px;
-}
-
-.youtube-section .video-title {
-  flex: 1;
-  font-size: 14px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-@media (max-width: 768px) {
-  .youtube-section {
-    flex-direction: column;
-  }
-  .youtube-section .channel-list {
-    order: 2;
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 80%;
-    max-width: 280px;
-    background: #fff;
-    z-index: 1500;
-    padding: 20px;
-    overflow-y: auto;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
-    pointer-events: none;
-  }
-  .youtube-section .channel-list.open {
-    transform: translateX(0);
-    pointer-events: auto;
-  }
-  .youtube-section .video-section {
-    order: 1;
-  }
-  .channel-toggle {
-    display: block;
-  }
-}
-
-/* Consistent video player sizing across pages */
-.live-player {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-}
-
-.live-player iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  display: block;
-}
-
-/* Styles specific to the radio list page */
-.radio-list {
-  font-family: Arial, sans-serif;
-  background-color: #f7f7f7;
-  color: #333;
-  margin: 0;
-  padding: 20px;
-}
-
-.radio-list h1 {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
-.radio-list p {
-  text-align: center;
-  max-width: 800px;
-  margin: auto;
-  line-height: 1.5;
-}
-
-.radio-list table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 20px;
-}
-
-.radio-list th,
-.radio-list td {
-  padding: 10px;
-  border: 1px solid #ddd;
-  vertical-align: top;
-}
-
-.radio-list th {
-  background-color: #fafafa;
-  font-weight: bold;
-}
-
-.radio-list audio {
-  display: none;
-}
-
-.radio-list .play-btn {
-  padding: 6px 12px;
-  font-size: 0.9em;
-  cursor: pointer;
-  background-color: #0066cc;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-}
-
-.radio-list .play-btn:hover {
-  background-color: #0052a3;
-}
-
-.radio-list .station-name {
-  font-weight: bold;
-}
-
-.radio-list .source-note {
-  margin-top: 30px;
-  font-size: 0.9em;
-  text-align: center;
-}
-
-/* Radio page player and favorites */
-#player-container {
-  text-align: center;
-  margin: 20px auto;
-  padding: 20px;
-  border: 2px solid #0066cc;
-  border-radius: 12px;
-  background-color: #f9f9f9;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-#player-container audio {
-  display: none;
-}
-
-.favorite-btn, .fav-nav-btn, .play-pause-btn, .mute-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 32px;
-  height: 32px;
-  font-size: 24px;
-  line-height: 1;
-}
-
-.favorite-btn.favorited {
-  color: goldenrod;
-}
-
-#player-container .controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-}
-
-.radio-list tr.favorite {
-  background-color: #fff8e1;
-}
-
-.radio-list tr.favorite .station-name::before {
-  content: '\2605\0020'; /* Star with space */
-  color: goldenrod;
-}
-
-/* Blog Post Styles */
+/* Post layout */
 .post-container {
   padding: 20px;
   max-width: 800px;
   margin: auto;
   box-sizing: border-box;
+}
+
+.post {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 
 .post h1 {
@@ -454,7 +229,7 @@ footer {
 
 .post-meta,
 .post-author {
-  color: #555;
+  color: #777;
   font-size: 0.9em;
   margin-bottom: 8px;
 }
@@ -489,7 +264,7 @@ footer {
   text-decoration: underline;
 }
 
-/* Responsive for post layout */
+/* Responsive adjustments */
 @media (max-width: 600px) {
   .post h1 {
     font-size: 1.5em;
@@ -507,10 +282,23 @@ footer {
     margin: 15px 0;
   }
 
-  .post-meta,
-  .post-author,
-  .post-share {
-    margin-top: 10px;
+  nav ul {
+    flex-direction: column;
+    display: none;
+    background: var(--md-primary);
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    padding: 16px;
+  }
+
+  #nav-toggle:checked ~ nav ul {
+    display: flex;
+  }
+
+  nav li {
+    margin: 8px 0;
   }
 }
 
@@ -521,7 +309,6 @@ footer {
   align-items: center;
   justify-content: center;
   min-width: 60px;
-  width: 60px;
 }
 
 .play-btn .spinner {
@@ -547,4 +334,392 @@ footer {
   to {
     transform: rotate(360deg);
   }
+}
+
+/* Utility page for nadraimage */
+.utility-page {
+  text-align: center;
+  padding: 2rem;
+}
+
+.utility-page video,
+.utility-page canvas,
+.utility-page img {
+  max-width: 100%;
+  border: 1px solid #ccc;
+  margin-top: 1rem;
+  border-radius: 4px;
+}
+
+.utility-page button {
+  margin: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 16px;
+  margin-top: 40px;
+  color: var(--md-on-surface);
+}
+
+.ad-container {
+  margin: 20px 0;
+  text-align: center;
+}
+body {
+  font-family: 'Roboto', sans-serif;
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  padding: 0;
+  margin: 0;
+}
+
+/* Top app bar */
+.top-bar {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 56px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.logo-title h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  line-height: 56px;
+}
+
+.nav-toggle-label {
+  color: var(--md-on-primary);
+  font-size: 1.5rem;
+  margin-right: 16px;
+  cursor: pointer;
+}
+
+nav {
+  flex-grow: 1;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+nav li {
+  margin-right: 16px;
+}
+
+nav a {
+  color: var(--md-on-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+#nav-toggle {
+  display: none;
+}
+
+/* Generic sections */
+section {
+  background: var(--md-surface);
+  margin: 20px auto;
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  max-width: 960px;
+}
+
+.hero {
+  text-align: center;
+  padding: 40px 20px;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin: 20px auto;
+}
+
+.hero img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 16px;
+}
+
+/* Card-like elements */
+.channel-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.channel-card {
+  background: var(--md-surface);
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.channel-card:hover {
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}
+
+.channel-card.active {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.video-section {
+  margin-top: 16px;
+}
+
+.video-section iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
+}
+
+.video-list .video-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.video-list .video-item img {
+  width: 120px;
+  height: 67px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.video-list .video-item.active {
+  background: rgba(0,100,0,0.1);
+}
+
+/* Buttons */
+button,
+.channel-toggle,
+.play-btn {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.play-btn:hover {
+  background: #004d00;
+}
+
+/* Radio player controls */
+.radio-player {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  margin-bottom: 16px;
+}
+
+.controls button {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 4px;
+}
+
+/* Tables */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  text-align: left;
+}
+
+/* Post layout */
+.post-container {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+  box-sizing: border-box;
+}
+
+.post {
+  background: var(--md-surface);
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.post h1 {
+  font-size: 2em;
+  margin-bottom: 10px;
+  color: #263238;
+}
+
+.post-meta,
+.post-author {
+  color: #777;
+  font-size: 0.9em;
+  margin-bottom: 8px;
+}
+
+.post-featured-image {
+  width: 100%;
+  height: auto;
+  margin: 20px 0;
+  border-radius: 8px;
+}
+
+.post-content {
+  line-height: 1.7;
+  font-size: 1em;
+  color: #333;
+}
+
+.post-share {
+  margin-top: 30px;
+  font-size: 0.9em;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+}
+
+.post-share a {
+  text-decoration: none;
+  margin-right: 10px;
+  color: #1E88E5;
+}
+
+.post-share a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .post h1 {
+    font-size: 1.5em;
+  }
+
+  .post-container {
+    padding: 15px;
+  }
+
+  .post-content {
+    font-size: 0.95em;
+  }
+
+  .post-featured-image {
+    margin: 15px 0;
+  }
+
+  nav ul {
+    flex-direction: column;
+    display: none;
+    background: var(--md-primary);
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    padding: 16px;
+  }
+
+  #nav-toggle:checked ~ nav ul {
+    display: flex;
+  }
+
+  nav li {
+    margin: 8px 0;
+  }
+}
+
+/* Spinner styles for radio play buttons */
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 60px;
+}
+
+.play-btn .spinner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Utility page for nadraimage */
+.utility-page {
+  text-align: center;
+  padding: 2rem;
+}
+
+.utility-page video,
+.utility-page canvas,
+.utility-page img {
+  max-width: 100%;
+  border: 1px solid #ccc;
+  margin-top: 1rem;
+  border-radius: 4px;
+}
+
+.utility-page button {
+  margin: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 16px;
+  margin-top: 40px;
+  color: var(--md-on-surface);
+}
+
+.ad-container {
+  margin: 20px 0;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- Replaced default Material purple with site's original blue palette for consistent branding.
- Tuned PakStream styles to use green accents and a red logo, matching the page's original colors.
- Maintained Material Design cards and buttons while preserving existing color themes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6e9a658083208fb63ac0e9639041