### PR TITLE
Add translation playback feature

### DIFF
--- a/test.html
+++ b/test.html
@@ -148,10 +148,24 @@
             const value = parsed[key] ?? '';
             const isReadOnly = key === 'wordClass' || key === 'en_US word';
             const row = document.createElement('div');
-            row.innerHTML = `
-              <label>${key}</label>
-              <input type="text" name="${key}" value="${value}" ${isReadOnly ? 'readonly' : ''} />
-            `;
+
+            const labelEl = document.createElement('label');
+            labelEl.textContent = key;
+
+            const inputEl = document.createElement('input');
+            inputEl.type = 'text';
+            inputEl.name = key;
+            inputEl.value = value;
+            if (isReadOnly) inputEl.setAttribute('readonly', true);
+
+            const playBtn = document.createElement('button');
+            playBtn.type = 'button';
+            playBtn.textContent = '▶';
+            playBtn.addEventListener('click', () => playText(key, inputEl.value));
+
+            row.appendChild(labelEl);
+            row.appendChild(inputEl);
+            row.appendChild(playBtn);
             editor.appendChild(row);
           });
 
@@ -204,6 +218,37 @@
         output.style.display = "block";
         output.textContent = "❌ Error: " + err.message;
       }
+    }
+
+    function playText(key, text) {
+      if (!window.speechSynthesis) return;
+
+      const prefix = key.split(' ')[0];
+      const requestedLang = prefix.includes('_')
+        ? prefix.replace('_', '-')
+        : 'en-US';
+
+      const voices = speechSynthesis.getVoices();
+      if (!voices.length) {
+        speechSynthesis.onvoiceschanged = () => playText(key, text);
+        return;
+      }
+
+      const utter = new SpeechSynthesisUtterance(text);
+      let voice = voices.find(v => v.lang === requestedLang);
+      if (!voice) {
+        const base = requestedLang.split('-')[0];
+        voice = voices.find(v => v.lang.startsWith(base));
+      }
+      if (voice) {
+        utter.voice = voice;
+        utter.lang = voice.lang;
+      } else {
+        utter.lang = requestedLang;
+      }
+
+      speechSynthesis.cancel();
+      speechSynthesis.speak(utter);
     }
 
     document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- add play buttons to translation fields for audio playback
- implement language-aware `playText` using Web Speech API
- improve voice selection for Urdu and other locales with language fallbacks

## Testing
- `jekyll build >/tmp/jekyll.log && tail -n 20 /tmp/jekyll.log`
- `npm test >/tmp/npm-test.log && tail -n 20 /tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_68910e02d4c88320a1819c32cb56e255