### PR TITLE
feat: responsive channel menu

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -137,33 +137,45 @@ section {
   color: #777;
 }
 
-/* Card-like elements */
-.channel-list {
+/* Channel navigation layout */
+.youtube-section {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 16px;
 }
 
-.channel-card {
+.youtube-section .channel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 220px;
+}
+
+.youtube-section .channel-card {
   background: var(--md-surface);
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: 8px 16px;
+  border-radius: 20px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
   cursor: pointer;
-  transition: box-shadow 0.2s;
+  transition: box-shadow 0.2s, background 0.2s;
+  user-select: none;
 }
 
-.channel-card:hover {
+.youtube-section .channel-card:hover {
   box-shadow: 0 4px 6px rgba(0,0,0,0.3);
 }
 
-.channel-card.active {
+.youtube-section .channel-card.active {
   background: var(--md-primary);
   color: var(--md-on-primary);
 }
 
 .video-section {
   margin-top: 16px;
+}
+
+.youtube-section .video-section {
+  flex: 1;
+  margin-top: 0;
 }
 
 .video-section iframe {
@@ -191,6 +203,47 @@ section {
 
 .video-list .video-item.active {
   background: rgba(0,100,0,0.1);
+}
+
+/* Responsive behaviour for channel list */
+@media (max-width: 768px) {
+  .youtube-section {
+    display: block;
+  }
+  .youtube-section .channel-list {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    bottom: 0;
+    width: 260px;
+    max-width: 80%;
+    background: var(--md-surface);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+    overflow-y: auto;
+    padding: 16px 8px;
+    z-index: 1001;
+  }
+  .youtube-section .channel-list.open {
+    transform: translateX(0);
+  }
+  .youtube-section .channel-toggle {
+    display: inline-block;
+    margin-bottom: 8px;
+  }
+}
+
+@media (min-width: 769px) {
+  .youtube-section .channel-toggle {
+    display: none;
+  }
+  .youtube-section .channel-list {
+    position: sticky;
+    top: 72px;
+    max-height: calc(100vh - 88px);
+    overflow-y: auto;
+  }
 }
 
 /* Buttons */

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -35,7 +35,6 @@
 
   <!-- YouTube section with channel list and video player -->
   <section class="youtube-section">
-    <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()">Channels</button>
     <div class="channel-list">
       <div class="channel-card active" data-channel-id="UCaszgR2TH3qNw_CxLHAd2SQ">Imran&nbsp;Riaz&nbsp;Khan</div>
       <div class="channel-card" data-channel-id="UCY7eFg5TEMsk_aTqM0pVB4w">Sabir&nbsp;Shakir</div>
@@ -59,10 +58,11 @@
       <div class="channel-card" data-channel-id="UCFqjOGv7tON3rY9kHPLa-OQ">Waqar Malik</div>
       <div class="channel-card" data-channel-id="UCAyd8kYxON-KM0UuRuK_sIg">Syed Muzammil</div>
       <div class="channel-card" data-channel-id="UCzVdIJeAwQfBZbG_8AOXgBw">Naya Daur TV</div>
-    
+
     </div>
     <!-- Video display area: a player for the selected video and a list of recent videos -->
     <div class="video-section">
+      <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()">Channels</button>
       <div class="live-player">
         <iframe id="playerFrame" src="" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
       </div>


### PR DESCRIPTION
## Summary
- add responsive channel navigation that slides in on mobile and displays as a vertical menu with material-style chips on larger screens
- reposition YouTube channel toggle within the player section for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891143e30f083208f6c52259d1713cf