### PR TITLE
Fix mobile menu closing redirects

### DIFF
--- a/pakstream/js/menu.js
+++ b/pakstream/js/menu.js
@@ -7,26 +7,10 @@ document.addEventListener('DOMContentLoaded', function () {
   label.addEventListener('click', function (e) {
     e.preventDefault();
     navToggle.checked = !navToggle.checked;
-    navToggle.dispatchEvent(new Event('change'));
-  });
-
-  navToggle.addEventListener('change', function () {
-    if (navToggle.checked) {
-      history.pushState({ menuOpen: true }, '');
-    } else if (history.state && history.state.menuOpen) {
-      history.back();
-    }
   });
 
   document.addEventListener('click', function (e) {
     if (navToggle.checked && !nav.contains(e.target) && !label.contains(e.target)) {
-      navToggle.checked = false;
-      navToggle.dispatchEvent(new Event('change'));
-    }
-  });
-
-  window.addEventListener('popstate', function () {
-    if (navToggle.checked) {
       navToggle.checked = false;
     }
   });


### PR DESCRIPTION
## Summary
- Remove history state management from menu.js so closing the mobile menu doesn't navigate away
- Simplify click handlers to just toggle the menu without interfering with page history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689116abdfbc832098bd5f5871fa2af9