### PR TITLE
Make video list scrollable

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -176,6 +176,9 @@ section {
 .youtube-section .video-section {
   flex: 1;
   margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
 }
 
 .video-section iframe {
@@ -183,6 +186,11 @@ section {
   height: 315px;
   border: none;
   border-radius: 4px;
+}
+
+.video-section .video-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .video-list .video-item {


### PR DESCRIPTION
## Summary
- Limit video section height and make it a flex column so the player remains visible.
- Allow the list of upcoming videos to scroll independently of the rest of the page.

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689119792f44832092e182eb299eef58