### PR TITLE
feat: revamp radio player UI

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -266,14 +266,61 @@ button:hover,
 
 /* Radio player controls */
 .radio-player {
-  background: var(--md-surface);
+  background: linear-gradient(180deg, #ffffff, #e8f5e9);
   padding: 16px;
-  border-radius: 4px;
+  border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
   margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.station-info {
+  text-align: center;
+}
+
+.station-info img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-bottom: 8px;
+}
+
+.station-title {
+  font-weight: 700;
+  margin: 0;
+}
+
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 12px;
+  background: #ffebee;
+  color: #d32f2f;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.live-badge .dot {
+  width: 8px;
+  height: 8px;
+  background: #d32f2f;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 12px;
 }
 
 .controls button {
+  border: none;
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -281,6 +328,18 @@ button:hover,
   align-items: center;
   justify-content: center;
   margin: 0 4px;
+  background: #009688;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.controls button:hover {
+  background: #00796b;
+}
+
+.controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Tables */

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -38,7 +38,11 @@
   <section>
     <h2>Pakistani Radio Stations</h2>
     <div id="player-container" class="radio-player">
-      <h3 id="current-station">Select a station</h3>
+      <div class="station-info">
+        <img id="station-logo" alt="Station logo" hidden>
+        <h3 id="current-station" class="station-title">Select a station</h3>
+        <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
+      </div>
       <div class="controls">
         <button id="favorite-btn" class="favorite-btn material-icons" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
         <button id="prev-fav-btn" class="fav-nav-btn material-icons" type="button" aria-label="Previous favorite" disabled>skip_previous</button>
@@ -392,6 +396,8 @@
 document.addEventListener('DOMContentLoaded', function() {
   const mainPlayer = document.getElementById('radio-player');
   const currentLabel = document.getElementById('current-station');
+  const stationLogo = document.getElementById('station-logo');
+  const liveBadge = document.getElementById('live-badge');
   const playButtons = Array.from(document.querySelectorAll('.play-btn'));
   const favBtn = document.getElementById('favorite-btn');
   const prevFavBtn = document.getElementById('prev-fav-btn');
@@ -459,6 +465,8 @@ document.addEventListener('DOMContentLoaded', function() {
     mainPlayer.removeAttribute('src');
     mainPlayer.load();
     currentLabel.textContent = 'Select a station';
+    stationLogo.hidden = true;
+    liveBadge.hidden = true;
     history.replaceState(null, '', window.location.pathname);
     resetButton(currentBtn);
     currentBtn = null;
@@ -476,6 +484,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     pendingBtn = btn;
     btn.classList.add('loading');
+    stationLogo.src = audio.dataset.logo || 'https://via.placeholder.com/80?text=Logo';
+    stationLogo.hidden = false;
+    liveBadge.hidden = true;
     mainPlayer.src = audio.src;
     mainPlayer.load();
     const playPromise = mainPlayer.play();
@@ -576,6 +587,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   mainPlayer.addEventListener('playing', () => {
     playPauseBtn.textContent = 'pause';
+    liveBadge.hidden = false;
     if (pendingBtn) {
       pendingBtn.classList.remove('loading');
       pendingBtn.querySelector('.label').textContent = 'Stop';
@@ -590,6 +602,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!mainPlayer.src) return;
     resetButton(currentBtn);
     playPauseBtn.textContent = 'play_arrow';
+    liveBadge.hidden = true;
   });
 
   mainPlayer.addEventListener('error', () => {
@@ -597,6 +610,8 @@ document.addEventListener('DOMContentLoaded', function() {
     currentBtn = null;
     pendingBtn = null;
     currentAudio = null;
+    liveBadge.hidden = true;
+    stationLogo.hidden = true;
     updateFavoritesUI();
   });
 


### PR DESCRIPTION
## Summary
- refresh radio player layout with gradient background and centered station info
- add station logo placeholder, bold station name, and live badge that appears during playback
- style control buttons as round teal icons for favorites, playback, and volume

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68911a9ddcf08320a480c19f61148a0f