### PR TITLE
Auto-play first radio station when no station selected

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -631,6 +631,16 @@ document.addEventListener('DOMContentLoaded', function() {
       resetButton(currentBtn);
       loadStation(audio, name, btn);
     }
+  } else {
+    const rows = document.querySelectorAll('table tbody tr');
+    if (rows.length > 1) {
+      const firstRow = rows[1]; // first station after the header row
+      const audio = firstRow.querySelector('audio');
+      const btn = firstRow.querySelector('.play-btn');
+      const name = firstRow.querySelector('.station-name').textContent;
+      resetButton(currentBtn);
+      loadStation(audio, name, btn);
+    }
   }
 });
   </script>


### PR DESCRIPTION
## Summary
- Automatically loads and plays the first radio station when visiting `/pakstream/radio.html` without a `station` query parameter.

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68911e14c95c83209aae35f93111418b