### PR TITLE
Fix live badge visibility for radio player

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -8,6 +8,10 @@
   --md-on-surface: #333333;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 
 body {
   font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
## Summary
- Respect the `hidden` attribute so the radio player's live badge only shows once audio is playing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891226aec1c8320b1ba02cf94b8cac8