### PR TITLE
Improve mobile controls layout and card spacing

### DIFF
--- a/test.html
+++ b/test.html
@@ -5,23 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
     body { font-family: sans-serif; padding: 2rem; text-align: center; }
-    input, button, textarea { font-size: 1rem; padding: 0.4rem; margin: 0.4rem; }
+    input, button, textarea { font-size: 1rem; padding: 0.3rem; margin: 0.2rem; }
     pre { background: #f4f4f4; padding: 1rem; border-radius: 8px; max-width: 800px; margin: 1rem auto; text-align: left; }
-    .edit-box { display: flex; flex-direction: column; gap: 12px; margin: 1rem auto; width: 80%; max-width: 600px; }
-    .translation-row { display: flex; gap: 1rem; align-items: center; background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 0.8rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .edit-box { display: flex; flex-direction: column; gap: 8px; margin: 1rem auto; width: 80%; max-width: 600px; }
+    .translation-row { display: flex; gap: 0.5rem; align-items: center; background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 0.4rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
     .translation-row input { flex: 1; }
-    .row-top { display: flex; align-items: center; gap: 0.5rem; }
-    .row-top label { width: 180px; text-align: right; }
+    .row-top { display: flex; align-items: center; gap: 0.3rem; }
+    .row-top label { width: 150px; text-align: right; }
     .output-success { color: green; }
     #mainControls, #translationsEditor, #saveBtn, #output { display: none; }
 
     @media (max-width: 600px) {
       body { padding: 1rem; }
-      .edit-box { width: 100%; }
-      .translation-row { flex-direction: column; align-items: stretch; }
+      .edit-box { width: 100%; gap: 6px; }
+      .translation-row { flex-direction: column; align-items: stretch; padding: 0.3rem; gap: 0.3rem; }
       .row-top { width: 100%; justify-content: space-between; }
       .row-top label { width: auto; text-align: left; }
       input, textarea { width: 100%; box-sizing: border-box; }
+      #mainControls { display: flex; flex-wrap: wrap; justify-content: center; }
+      #mainControls input { order: 1; flex-basis: 100%; }
+      #mainControls button { order: 2; flex: 1; }
     }
   </style>
 </head>
@@ -34,10 +37,10 @@
 
   <!-- Controls (hidden initially) -->
   <div id="mainControls">
-    <button onclick="getPrevWord()">Get Previous Word</button>
+    <button onclick="getPrevWord()">Previous Word</button>
     <input type="text" id="wordId" placeholder="Enter ID or Word" autocomplete="off" />
     <button onclick="getWord()">Get Word</button>
-    <button onclick="getNextWord()">Get Next Word</button>
+    <button onclick="getNextWord()">Next Word</button>
   </div>
 
   <!-- Editor -->


### PR DESCRIPTION
## Summary
- Make word ID input appear above navigation buttons on small screens
- Tighten spacing inside translation cards for less scrolling
- Rename navigation buttons for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891230942d4832091aede6ccf4d794a