### PR TITLE
Implement dark mode and update branding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -69,7 +69,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <main>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta charset="UTF-8" />
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad" />
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world." />
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico" />
+  <meta property="og:image" content="/favicon.ico" />
   <meta property="og:url" content="https://pakstream.com/" />
   <meta property="og:type" content="website" />
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad" />
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live." />
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico" />
+  <meta name="twitter:image" content="/favicon.ico" />
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en" />
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -67,7 +67,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <main class="post-container">

--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,14 @@
   --md-on-surface: #333333;
 }
 
+body.dark-mode {
+  --md-primary: #263238;
+  --md-on-primary: #ffffff;
+  --md-surface: #37474f;
+  --md-background: #263238;
+  --md-on-surface: #e0e0e0;
+}
+
 
 body {
   font-family: 'Roboto', sans-serif;
@@ -15,6 +23,7 @@ body {
   color: var(--md-on-surface);
   padding: 0;
   margin: 0;
+  transition: background 0.3s, color 0.3s;
 }
 
 h1 {
@@ -41,6 +50,7 @@ h3 {
   padding: 0 16px;
   height: 56px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  border-bottom: 2px solid #0d47a1;
 }
 
 .logo-title h1 {
@@ -80,10 +90,20 @@ nav a {
 
 nav a:hover {
   text-decoration: underline;
+  color: #bbdefb;
 }
 
 #nav-toggle {
   display: none;
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--md-on-primary);
+  cursor: pointer;
+  font-size: 1.25rem;
+  margin-left: 16px;
 }
 
 /* Generic sections */

--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Hero section with image and tagline -->
@@ -79,7 +80,7 @@
     <img src="pakstream/images/pakistan-abstract.png" alt="PakStream decorative image">
     <div class="hero-text">
       <h2>Your Gateway to Pakistani Media</h2>
-      <p>Radio, TV &amp; YouTube in one place</p>
+      <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
     </div>
   </section>
 

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -67,7 +67,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
   <h1>Passport Photo Resizer (35x45mm)</h1>
   <video id="video" autoplay playsinline width="400"></video><br>

--- a/nav.html
+++ b/nav.html
@@ -17,5 +17,6 @@
       <li><a href="/pakstream/terms.html">Terms</a></li>
     </ul>
   </nav>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
 </header>

--- a/pakstream/about.html
+++ b/pakstream/about.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -70,7 +70,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- About section describing the mission of PakStream -->

--- a/pakstream/contact.html
+++ b/pakstream/contact.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Contact section with instructions to reach us -->

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -8,6 +8,14 @@
   --md-on-surface: #333333;
 }
 
+body.dark-mode {
+  --md-primary: #263238;
+  --md-on-primary: #ffffff;
+  --md-surface: #37474f;
+  --md-background: #263238;
+  --md-on-surface: #e0e0e0;
+}
+
 [hidden] {
   display: none !important;
 }
@@ -19,6 +27,7 @@ body {
   color: var(--md-on-surface);
   padding: 0;
   margin: 0;
+  transition: background 0.3s, color 0.3s;
 }
 
 /* Top app bar */
@@ -30,6 +39,7 @@ body {
   padding: 0 16px;
   height: 56px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  border-bottom: 2px solid #004d00;
   position: relative;
   z-index: 1002;
 }
@@ -38,7 +48,7 @@ body {
   font-size: 1.25rem;
   margin: 0;
   line-height: 56px;
-  color: #cc0000;
+  color: #263238;
 }
 
 .nav-toggle-label {
@@ -72,6 +82,7 @@ nav a {
 
 nav a:hover {
   text-decoration: underline;
+  color: #c5e1a5;
 }
 
 #nav-toggle {
@@ -80,6 +91,15 @@ nav a:hover {
 
 .nav-overlay {
   display: none;
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--md-on-primary);
+  cursor: pointer;
+  font-size: 1.25rem;
+  margin-left: 16px;
 }
 
 /* Generic sections */

--- a/pakstream/index.html
+++ b/pakstream/index.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Hero section with image and tagline -->
@@ -79,7 +80,7 @@
     <img src="images/pakistan-abstract.png" alt="PakStream decorative image">
     <div class="hero-text">
       <h2>Your Gateway to Pakistani Media</h2>
-      <p>Radio, TV &amp; YouTube in one place</p>
+      <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
     </div>
   </section>
 

--- a/pakstream/js/menu.js
+++ b/pakstream/js/menu.js
@@ -14,4 +14,17 @@ document.addEventListener('DOMContentLoaded', function () {
       navToggle.checked = false;
     }
   });
+
+  var themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    var savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+      document.body.classList.add('dark-mode');
+    }
+    themeToggle.addEventListener('click', function () {
+      document.body.classList.toggle('dark-mode');
+      var mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+      localStorage.setItem('theme', mode);
+    });
+  }
 });

--- a/pakstream/privacy.html
+++ b/pakstream/privacy.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Privacy policy content -->

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Radio station listing -->

--- a/pakstream/terms.html
+++ b/pakstream/terms.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -71,7 +71,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- Terms and conditions content -->

--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta charset="UTF-8" />
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad" />
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world." />
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico" />
+  <meta property="og:image" content="/favicon.ico" />
   <meta property="og:url" content="https://pakstream.com/" />
   <meta property="og:type" content="website" />
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad" />
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live." />
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico" />
+  <meta name="twitter:image" content="/favicon.ico" />
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en" />
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -68,7 +68,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
 

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
@@ -70,7 +70,8 @@
         <li><a href="/pakstream/terms.html">Terms</a></li>
       </ul>
     </nav>
-    <label for="nav-toggle" class="nav-overlay"></label>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
   <!-- YouTube section with channel list and video player -->

--- a/test.html
+++ b/test.html
@@ -8,12 +8,12 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="icon" href="https://neurolingo.cc/pakstream/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
-  <meta property="og:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
-  <meta name="twitter:image" content="https://neurolingo.cc/pakstream/favicon.ico">
+  <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
   <meta http-equiv="Content-Language" content="en">
@@ -33,7 +33,7 @@
     "@type": "Organization",
     "name": "PakStream",
     "url": "https://pakstream.com",
-    "logo": "https://neurolingo.cc/pakstream/favicon.ico",
+    "logo": "/favicon.ico",
     "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"


### PR DESCRIPTION
## Summary
- add dark/light mode toggle with persistent preference
- enhance navbar with hover color and bottom border
- replace external favicon with local asset and update hero tagline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913fe5f4688320851aade6d84c80b3