### PR TITLE
Add Material Design theming with light/dark mode

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,6 +47,7 @@
 
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,6 +45,7 @@
   }
   </script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css" />
 </head>
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -1,26 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
-:root {
-  --md-primary: #1E88E5;
-  --md-on-primary: #ffffff;
-  --md-surface: #ffffff;
-  --md-background: #f9f9f9;
-  --md-on-surface: #333333;
-}
-
-body.dark-mode {
-  --md-primary: #263238;
-  --md-on-primary: #ffffff;
-  --md-surface: #37474f;
-  --md-background: #263238;
-  --md-on-surface: #e0e0e0;
-}
-
 
 body {
   font-family: 'Roboto', sans-serif;
-  background: var(--md-background);
-  color: var(--md-on-surface);
+  background: var(--background);
+  color: var(--on-surface);
   padding: 0;
   margin: 0;
   transition: background 0.3s, color 0.3s;
@@ -43,8 +27,8 @@ h3 {
 
 /* Top app bar */
 .top-bar {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   display: flex;
   align-items: center;
   padding: 0 16px;
@@ -60,7 +44,7 @@ h3 {
 }
 
 .nav-toggle-label {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   font-size: 1.5rem;
   margin-right: 16px;
   cursor: pointer;
@@ -83,7 +67,7 @@ nav li {
 }
 
 nav a {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -100,7 +84,7 @@ nav a:hover {
 .theme-toggle {
   background: none;
   border: none;
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   cursor: pointer;
   font-size: 1.25rem;
   margin-left: 16px;
@@ -108,7 +92,7 @@ nav a:hover {
 
 /* Generic sections */
 section {
-  background: var(--md-surface);
+  background: var(--surface);
   margin: 20px auto;
   padding: 16px;
   border-radius: 4px;
@@ -138,7 +122,7 @@ section {
   left: 50%;
   transform: translate(-50%, -50%);
   background: rgba(0,0,0,0.4);
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   padding: 20px;
   border-radius: 8px;
 }
@@ -153,7 +137,7 @@ section {
 }
 
 .feature-card {
-  background: var(--md-surface);
+  background: var(--surface);
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -163,7 +147,7 @@ section {
 
 .feature-card .material-icons {
   font-size: 48px;
-  color: var(--md-primary);
+  color: var(--primary);
   margin-bottom: 10px;
 }
 
@@ -175,7 +159,7 @@ section {
 }
 
 .channel-card {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 8px 12px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -188,8 +172,8 @@ section {
 }
 
 .channel-card.active {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
 }
 
 .video-section {
@@ -227,8 +211,8 @@ section {
 button,
 .channel-toggle,
 .play-btn {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   border: none;
   border-radius: 4px;
   padding: 8px 16px;
@@ -243,7 +227,7 @@ button:hover,
 
 /* Radio player controls */
 .radio-player {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 16px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -284,7 +268,7 @@ th {
 }
 
 .post {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 16px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -354,7 +338,7 @@ th {
   nav ul {
     flex-direction: column;
     display: none;
-    background: var(--md-primary);
+    background: var(--primary);
     position: absolute;
     top: 56px;
     left: 0;
@@ -428,7 +412,7 @@ footer {
   text-align: center;
   padding: 16px;
   margin-top: 40px;
-  color: var(--md-on-surface);
+  color: var(--on-surface);
 }
 
 footer nav {
@@ -436,7 +420,7 @@ footer nav {
 }
 
 footer nav a {
-  color: var(--md-on-surface);
+  color: var(--on-surface);
   margin: 0 8px;
   text-decoration: none;
 }
@@ -451,16 +435,16 @@ footer nav a:hover {
 }
 body {
   font-family: 'Roboto', sans-serif;
-  background: var(--md-background);
-  color: var(--md-on-surface);
+  background: var(--background);
+  color: var(--on-surface);
   padding: 0;
   margin: 0;
 }
 
 /* Top app bar */
 .top-bar {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   display: flex;
   align-items: center;
   padding: 0 16px;
@@ -475,7 +459,7 @@ body {
 }
 
 .nav-toggle-label {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   font-size: 1.5rem;
   margin-right: 16px;
   cursor: pointer;
@@ -498,7 +482,7 @@ nav li {
 }
 
 nav a {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -521,7 +505,7 @@ nav a:hover {
 }
 
 .channel-card {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 8px 12px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -534,8 +518,8 @@ nav a:hover {
 }
 
 .channel-card.active {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
 }
 
 .video-section {
@@ -573,8 +557,8 @@ nav a:hover {
 button,
 .channel-toggle,
 .play-btn {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   border: none;
   border-radius: 4px;
   padding: 8px 16px;
@@ -589,7 +573,7 @@ button:hover,
 
 /* Radio player controls */
 .radio-player {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 16px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -631,7 +615,7 @@ th {
 }
 
 .post {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 16px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -701,7 +685,7 @@ th {
   nav ul {
     flex-direction: column;
     display: none;
-    background: var(--md-primary);
+    background: var(--primary);
     position: absolute;
     top: 56px;
     left: 0;
@@ -775,7 +759,7 @@ footer {
   text-align: center;
   padding: 16px;
   margin-top: 40px;
-  color: var(--md-on-surface);
+  color: var(--on-surface);
 }
 
 .ad-container {

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,0 +1,59 @@
+/* ===== Material Design Inspired Theme ===== */
+
+/* -------- Light Theme -------- */
+:root {
+  --primary: #00796B;
+  --on-primary: #FFFFFF;
+  --primary-container: #B2DFDB;
+  --on-primary-container: #004D40;
+
+  --secondary: #C62828;
+  --on-secondary: #FFFFFF;
+
+  --background: #FAFAFA;
+  --on-background: #212121;
+
+  --surface: #FFFFFF;
+  --on-surface: #212121;
+
+  --error: #D32F2F;
+  --on-error: #FFFFFF;
+
+  --outline: #BDBDBD;
+  --surface-variant: #EEEEEE;
+  --on-surface-variant: #424242;
+
+  --accent-live: #FB8C00;
+  --accent-link: #1E88E5;
+  --accent-success: #43A047;
+  --accent-info: #4FC3F7;
+}
+
+/* -------- Dark Theme -------- */
+[data-theme="dark"] {
+  --primary: #80CBC4;
+  --on-primary: #00332C;
+  --primary-container: #004D40;
+  --on-primary-container: #B2DFDB;
+
+  --secondary: #EF9A9A;
+  --on-secondary: #3C0404;
+
+  --background: #121212;
+  --on-background: #E0E0E0;
+
+  --surface: #1E1E1E;
+  --on-surface: #F5F5F5;
+
+  --error: #EF9A9A;
+  --on-error: #3C0404;
+
+  --outline: #424242;
+  --surface-variant: #2C2C2C;
+  --on-surface-variant: #DDDDDD;
+
+  --accent-live: #FFB74D;
+  --accent-link: #90CAF9;
+  --accent-success: #66BB6A;
+  --accent-info: #81D4FA;
+}

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -45,6 +45,7 @@
   }
   </script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body class="utility-page">

--- a/pakstream/about.html
+++ b/pakstream/about.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/pakstream/contact.html
+++ b/pakstream/contact.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -1,21 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
-:root {
-  --md-primary: #006400;
-  --md-on-primary: #ffffff;
-  --md-surface: #ffffff;
-  --md-background: #f5f5f5;
-  --md-on-surface: #333333;
-}
-
-body.dark-mode {
-  --md-primary: #263238;
-  --md-on-primary: #ffffff;
-  --md-surface: #37474f;
-  --md-background: #263238;
-  --md-on-surface: #e0e0e0;
-}
-
 [hidden] {
   display: none !important;
 }
@@ -23,8 +7,8 @@ body.dark-mode {
 
 body {
   font-family: 'Roboto', sans-serif;
-  background: var(--md-background);
-  color: var(--md-on-surface);
+  background: var(--background);
+  color: var(--on-surface);
   padding: 0;
   margin: 0;
   transition: background 0.3s, color 0.3s;
@@ -32,8 +16,8 @@ body {
 
 /* Top app bar */
 .top-bar {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   display: flex;
   align-items: center;
   padding: 0 16px;
@@ -48,11 +32,11 @@ body {
   font-size: 1.25rem;
   margin: 0;
   line-height: 56px;
-  color: #263238;
+  color: var(--on-primary);
 }
 
 .nav-toggle-label {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   font-size: 1.5rem;
   margin-right: 16px;
   cursor: pointer;
@@ -75,7 +59,7 @@ nav li {
 }
 
 nav a {
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -96,7 +80,7 @@ nav a:hover {
 .theme-toggle {
   background: none;
   border: none;
-  color: var(--md-on-primary);
+  color: var(--on-primary);
   cursor: pointer;
   font-size: 1.25rem;
   margin-left: 16px;
@@ -104,7 +88,7 @@ nav a:hover {
 
 /* Generic sections */
 section {
-  background: var(--md-surface);
+  background: var(--surface);
   margin: 20px auto;
   padding: 16px;
   border-radius: 4px;
@@ -115,8 +99,8 @@ section {
 .hero {
   text-align: center;
   padding: 40px 20px;
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
   margin: 20px auto;
@@ -145,7 +129,7 @@ section {
 }
 
 .blog-post-item a {
-  color: var(--md-primary);
+  color: var(--primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -175,7 +159,7 @@ section {
 }
 
 .youtube-section .channel-card {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 8px 16px;
   border-radius: 20px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -189,8 +173,8 @@ section {
 }
 
 .youtube-section .channel-card.active {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
 }
 
 .video-section {
@@ -259,7 +243,7 @@ section {
     bottom: 0;
     width: 260px;
     max-width: 80%;
-    background: var(--md-surface);
+    background: var(--surface);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
@@ -292,8 +276,8 @@ section {
 button,
 .channel-toggle,
 .play-btn {
-  background: var(--md-primary);
-  color: var(--md-on-primary);
+  background: var(--primary);
+  color: var(--on-primary);
   border: none;
   border-radius: 4px;
   padding: 8px 16px;
@@ -436,7 +420,7 @@ table tbody tr.favorite {
 }
 
 .post {
-  background: var(--md-surface);
+  background: var(--surface);
   padding: 16px;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -509,8 +493,8 @@ table tbody tr.favorite {
     left: 0;
     bottom: 0;
     width: 250px;
-    background: var(--md-surface);
-    color: var(--md-on-surface);
+    background: var(--surface);
+    color: var(--on-surface);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
@@ -531,7 +515,7 @@ table tbody tr.favorite {
   }
 
   nav a {
-    color: var(--md-on-surface);
+    color: var(--on-surface);
     display: block;
     padding: 8px 0;
   }
@@ -622,7 +606,7 @@ footer {
   text-align: center;
   padding: 16px;
   margin-top: 40px;
-  color: var(--md-on-surface);
+  color: var(--on-surface);
 }
 
 footer nav {
@@ -630,7 +614,7 @@ footer nav {
 }
 
 footer nav a {
-  color: var(--md-on-surface);
+  color: var(--on-surface);
   margin: 0 8px;
   text-decoration: none;
 }

--- a/pakstream/css/theme.css
+++ b/pakstream/css/theme.css
@@ -1,0 +1,59 @@
+/* ===== Material Design Inspired Theme ===== */
+
+/* -------- Light Theme -------- */
+:root {
+  --primary: #00796B;
+  --on-primary: #FFFFFF;
+  --primary-container: #B2DFDB;
+  --on-primary-container: #004D40;
+
+  --secondary: #C62828;
+  --on-secondary: #FFFFFF;
+
+  --background: #FAFAFA;
+  --on-background: #212121;
+
+  --surface: #FFFFFF;
+  --on-surface: #212121;
+
+  --error: #D32F2F;
+  --on-error: #FFFFFF;
+
+  --outline: #BDBDBD;
+  --surface-variant: #EEEEEE;
+  --on-surface-variant: #424242;
+
+  --accent-live: #FB8C00;
+  --accent-link: #1E88E5;
+  --accent-success: #43A047;
+  --accent-info: #4FC3F7;
+}
+
+/* -------- Dark Theme -------- */
+[data-theme="dark"] {
+  --primary: #80CBC4;
+  --on-primary: #00332C;
+  --primary-container: #004D40;
+  --on-primary-container: #B2DFDB;
+
+  --secondary: #EF9A9A;
+  --on-secondary: #3C0404;
+
+  --background: #121212;
+  --on-background: #E0E0E0;
+
+  --surface: #1E1E1E;
+  --on-surface: #F5F5F5;
+
+  --error: #EF9A9A;
+  --on-error: #3C0404;
+
+  --outline: #424242;
+  --surface-variant: #2C2C2C;
+  --on-surface-variant: #DDDDDD;
+
+  --accent-live: #FFB74D;
+  --accent-link: #90CAF9;
+  --accent-success: #66BB6A;
+  --accent-info: #81D4FA;
+}

--- a/pakstream/index.html
+++ b/pakstream/index.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>

--- a/pakstream/js/menu.js
+++ b/pakstream/js/menu.js
@@ -17,14 +17,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
   var themeToggle = document.getElementById('theme-toggle');
   if (themeToggle) {
-    var savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
-      document.body.classList.add('dark-mode');
-    }
+    var savedTheme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', savedTheme);
     themeToggle.addEventListener('click', function () {
-      document.body.classList.toggle('dark-mode');
-      var mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
-      localStorage.setItem('theme', mode);
+      var current = document.documentElement.getAttribute('data-theme');
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
     });
   }
 });

--- a/pakstream/privacy.html
+++ b/pakstream/privacy.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>

--- a/pakstream/terms.html
+++ b/pakstream/terms.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -46,6 +46,7 @@
   </script>
 
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -48,6 +48,7 @@
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
+  <link rel="stylesheet" href="/pakstream/css/theme.css">
   <link rel="stylesheet" href="/pakstream/css/style.css">
 </head>
 <body>

--- a/test.html
+++ b/test.html
@@ -45,6 +45,7 @@
   }
   </script>
 
+  <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <style>
     body { font-family: sans-serif; padding: 2rem; text-align: center; }


### PR DESCRIPTION
## Summary
- introduce Material Design theme variables with light and dark palettes
- update styles to consume shared variables and drop old dark-mode class
- switch theme toggle script to use `data-theme` attribute persisted in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689143701fc483209c6a1cfe5498f4db