### PR TITLE
feat: display station logos in radio list

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -411,6 +411,14 @@ table tbody tr.favorite {
   background-color: #e8f5e9;
 }
 
+.station-row-logo {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
 /* Post layout */
 .post-container {
   padding: 20px;

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -511,6 +511,17 @@ document.addEventListener('DOMContentLoaded', function() {
   const nextFavBtn = document.getElementById('next-fav-btn');
   const muteBtn = document.getElementById('mute-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
+
+  // Insert station logos into each row before the play button
+  document.querySelectorAll('audio[data-logo]').forEach(audio => {
+    const btn = audio.parentElement.querySelector('.play-btn');
+    if (!btn) return;
+    const img = document.createElement('img');
+    img.src = audio.dataset.logo || defaultLogo;
+    img.alt = '';
+    img.className = 'station-row-logo';
+    audio.parentElement.insertBefore(img, btn);
+  });
   let currentBtn = null;
   let pendingBtn = null;
   let resumeHandler = null;


### PR DESCRIPTION
## Summary
- show each station's logo before its play button in the radio list
- add styling for consistent logo sizing and alignment

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68914528bd0c8320a28a2e96d0710d7a