### PR TITLE
Fix delayed channel list closure on mobile

### DIFF
--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -218,6 +218,13 @@
   
     setActiveCard(card);
     videoListEl.innerHTML = '<p>Loading videos…</p>';
+
+    // Close channel list immediately on small screens
+    if (window.innerWidth <= 768) {
+      const list = document.querySelector('.channel-list');
+      list.classList.remove('open');
+      document.getElementById('toggle-channels').textContent = 'Channels';
+    }
   
     if (!channelId) {
       videoListEl.innerHTML = '<p>No channel ID provided.</p>';
@@ -275,12 +282,6 @@
       videoListEl.innerHTML = '<p>Error loading videos.</p>';
     }
 
-    // Close channel list on small screens
-    if (window.innerWidth <= 768) {
-      const list = document.querySelector('.channel-list');
-      list.classList.remove('open');
-      document.getElementById('toggle-channels').textContent = 'Channels';
-    }
   }
 
   cards.forEach(card => {


### PR DESCRIPTION
## Summary
- Close the channel list immediately on small screens when selecting a channel so the menu hides without delay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689146533bd88320bd2362f3019d2bb5