### PR TITLE
feat: display station logos in radio list

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -411,6 +411,26 @@ table tbody tr.favorite {
   background-color: #e8f5e9;
 }
 
+.radio-list td:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.radio-list td:first-child audio {
+  display: none;
+}
+
+.station-row-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
 /* Post layout */
 .post-container {
   padding: 20px;

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -511,6 +511,20 @@ document.addEventListener('DOMContentLoaded', function() {
   const nextFavBtn = document.getElementById('next-fav-btn');
   const muteBtn = document.getElementById('mute-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
+
+  // Insert station logos into each row before the play button
+  document.querySelectorAll('audio[data-logo]').forEach(audio => {
+    const btn = audio.parentElement.querySelector('.play-btn');
+    if (!btn) return;
+    const img = document.createElement('img');
+    img.src = audio.dataset.logo || defaultLogo;
+    img.alt = '';
+    img.className = 'station-row-logo';
+    img.width = 40;
+    img.height = 40;
+    img.loading = 'lazy';
+    audio.parentElement.insertBefore(img, btn);
+  });
   let currentBtn = null;
   let pendingBtn = null;
   let resumeHandler = null;
@@ -636,7 +650,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   playButtons.forEach(btn => {
-    const audio = btn.previousElementSibling;
+    const audio = btn.parentElement.querySelector('audio');
     const name = btn.closest('tr').querySelector('.station-name').textContent;
     const text = btn.textContent.trim();
     btn.setAttribute('type', 'button');


### PR DESCRIPTION
## Summary
- show each station's logo before its play button in the radio list
- constrain logo dimensions and layout to maintain responsiveness and follow Material guidelines
- ensure play buttons update the URL with the correct station ID

## Testing
- `jekyll build` *(command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68914528bd0c8320a28a2e96d0710d7a