### PR TITLE
Enable station-wide radio navigation

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -88,9 +88,9 @@
       </div>
       <div class="controls">
         <button id="favorite-btn" class="favorite-btn material-icons" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
-        <button id="prev-fav-btn" class="fav-nav-btn material-icons" type="button" aria-label="Previous favorite" disabled>skip_previous</button>
+        <button id="prev-btn" class="fav-nav-btn material-icons" type="button" aria-label="Previous station" disabled>skip_previous</button>
         <button id="play-pause-btn" class="play-pause-btn material-icons" type="button" aria-label="Play or pause" disabled>play_arrow</button>
-        <button id="next-fav-btn" class="fav-nav-btn material-icons" type="button" aria-label="Next favorite" disabled>skip_next</button>
+        <button id="next-btn" class="fav-nav-btn material-icons" type="button" aria-label="Next station" disabled>skip_next</button>
         <button id="mute-btn" class="mute-btn material-icons" type="button" aria-label="Mute" disabled>volume_up</button>
         <audio id="radio-player" autoplay></audio>
       </div>
@@ -506,9 +506,9 @@ document.addEventListener('DOMContentLoaded', function() {
   const notLiveBadge = document.getElementById('not-live-badge');
   const playButtons = Array.from(document.querySelectorAll('.play-btn'));
   const favBtn = document.getElementById('favorite-btn');
-  const prevFavBtn = document.getElementById('prev-fav-btn');
+  const prevBtn = document.getElementById('prev-btn');
   const playPauseBtn = document.getElementById('play-pause-btn');
-  const nextFavBtn = document.getElementById('next-fav-btn');
+  const nextBtn = document.getElementById('next-btn');
   const muteBtn = document.getElementById('mute-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
 
@@ -557,8 +557,8 @@ document.addEventListener('DOMContentLoaded', function() {
       muteBtn.disabled = true;
     }
 
-    const hasFavorites = favorites.length > 0;
-    prevFavBtn.disabled = nextFavBtn.disabled = !hasFavorites;
+    const hasStations = playButtons.length > 0;
+    prevBtn.disabled = nextBtn.disabled = !hasStations;
 
     playPauseBtn.textContent = mainPlayer.paused ? 'play_arrow' : 'pause';
     muteBtn.textContent = mainPlayer.muted ? 'volume_off' : 'volume_up';
@@ -682,27 +682,25 @@ document.addEventListener('DOMContentLoaded', function() {
     updateFavoritesUI();
   });
 
-  function playFavorite(offset) {
-    if (favorites.length === 0) return;
+  function playStation(offset) {
+    const audios = Array.from(document.querySelectorAll('table tbody audio'));
+    if (audios.length === 0) return;
     const currentId = currentAudio ? currentAudio.id : null;
-    let idx = currentId ? favorites.indexOf(currentId) : -1;
+    let idx = currentId ? audios.findIndex(a => a.id === currentId) : -1;
     if (idx === -1) {
-      idx = offset > 0 ? 0 : favorites.length - 1;
+      idx = offset > 0 ? 0 : audios.length - 1;
     } else {
-      idx = (idx + offset + favorites.length) % favorites.length;
+      idx = (idx + offset + audios.length) % audios.length;
     }
-    const nextId = favorites[idx];
-    const audio = document.getElementById(nextId);
-    if (audio) {
-      const name = audio.closest('tr').querySelector('.station-name').textContent;
-      const btn = audio.parentElement.querySelector('.play-btn');
-      resetButton(currentBtn);
-      loadStation(audio, name, btn);
-    }
+    const audio = audios[idx];
+    const name = audio.closest('tr').querySelector('.station-name').textContent;
+    const btn = audio.parentElement.querySelector('.play-btn');
+    resetButton(currentBtn);
+    loadStation(audio, name, btn);
   }
 
-  prevFavBtn.addEventListener('click', () => playFavorite(-1));
-  nextFavBtn.addEventListener('click', () => playFavorite(1));
+  prevBtn.addEventListener('click', () => playStation(-1));
+  nextBtn.addEventListener('click', () => playStation(1));
 
   playPauseBtn.addEventListener('click', () => {
     if (mainPlayer.paused) {


### PR DESCRIPTION
## Summary
- Extend radio player navigation to move through all stations sequentially with wrap-around.
- Update control buttons and UI logic to support station-wide navigation rather than favorites-only.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914bb39e708320a164d714b21ee08c