### PR TITLE
Improve home page tagline contrast in dark mode

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -140,6 +140,11 @@ section {
   border-radius: 8px;
 }
 
+/* Improve contrast for tagline in dark mode */
+[data-theme="dark"] .hero-text {
+  color: var(--on-primary-container);
+}
+
 /* Featured card layout */
 .feature-cards {
   display: flex;


### PR DESCRIPTION
## Summary
- Ensure hero tagline is readable in dark theme by using a lighter color variable

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68914c1fc2288320a00fce9a33abcd4f