### PR TITLE
style: customize dark mode favorite row

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -466,7 +466,7 @@ table tbody tr:not(:first-child) {
 }
 
 table tbody tr.favorite {
-  background-color: #e8f5e9;
+  background-color: var(--favorite-row);
 }
 
 .radio-list td:first-child {

--- a/pakstream/css/theme.css
+++ b/pakstream/css/theme.css
@@ -27,6 +27,7 @@
   --accent-link: #1E88E5;
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
+  --favorite-row: #e8f5e9;
 }
 
 /* -------- Dark Theme -------- */
@@ -56,4 +57,5 @@
   --accent-link: #90CAF9;
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
+  --favorite-row: #1B5E20;
 }


### PR DESCRIPTION
## Summary
- allow radio favorites to adopt theme-aware color via `--favorite-row`
- give dark mode favorite rows a rich deep-green background

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914cb2388083209dec1cc02e365026