### PR TITLE
feat: highlight radio stations on hover

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -469,6 +469,16 @@ table tbody tr:not(:first-child) {
 table tbody tr.favorite {
   background-color: var(--favorite-row);
 }
+/* Hover highlight for station rows on desktops */
+@media (hover: hover) and (pointer: fine) {
+  .radio-list table tbody tr:not(:first-child) {
+    transition: background-color 0.2s ease-in-out;
+  }
+
+  .radio-list table tbody tr:not(:first-child):hover {
+    background-color: var(--surface-variant);
+  }
+}
 
 .radio-list td:first-child {
   display: flex;


### PR DESCRIPTION
## Summary
- improve affordance by highlighting radio station rows on hover for desktop users

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll bundler` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68914feceb888320b0a0155772b580dc