### PR TITLE
Add mobile back navigation and smoother menu animation

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -42,6 +42,13 @@ body {
   cursor: pointer;
 }
 
+.back-button {
+  color: var(--on-primary);
+  font-size: 1.25rem;
+  margin-right: 16px;
+  text-decoration: none;
+}
+
 nav {
   flex-grow: 1;
 }
@@ -575,7 +582,8 @@ table tbody tr.favorite {
     background: var(--surface);
     color: var(--on-surface);
     transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    transition: transform 0.3s ease-in-out;
+    will-change: transform;
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
     z-index: 1001;
   }
@@ -617,6 +625,9 @@ table tbody tr.favorite {
 
 @media (min-width: 601px) {
   .nav-toggle-label {
+    display: none;
+  }
+  .back-button {
     display: none;
   }
   nav {

--- a/pakstream/js/menu.js
+++ b/pakstream/js/menu.js
@@ -12,6 +12,24 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
+  var topBar = document.querySelector('.top-bar');
+  var homePaths = ['/index.html', '/pakstream/index.html'];
+  if (topBar && label && homePaths.indexOf(currentPath) === -1) {
+    var backBtn = document.createElement('a');
+    backBtn.href = '/index.html';
+    backBtn.className = 'back-button';
+    backBtn.textContent = '←';
+    backBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (window.history.length > 1) {
+        window.history.back();
+      } else {
+        window.location.href = '/index.html';
+      }
+    });
+    topBar.insertBefore(backBtn, label.nextSibling);
+  }
+
   label.addEventListener('click', function (e) {
     e.preventDefault();
     navToggle.checked = !navToggle.checked;


### PR DESCRIPTION
## Summary
- add a persistent back button in the mobile header for easier navigation
- smooth mobile menu transition with eased transform

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689150520f148320a03072052e5a6c22