### PR TITLE
Ensure radio player adapts to dark mode

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -358,7 +358,7 @@ button:hover,
 
 /* Radio player controls */
 .radio-player {
-  background: linear-gradient(180deg, #ffffff, #e8f5e9);
+  background: linear-gradient(180deg, var(--surface), var(--surface-variant));
   padding: 16px;
   border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -440,13 +440,13 @@ button:hover,
   align-items: center;
   justify-content: center;
   margin: 0 4px;
-  background: #009688;
-  color: #ffffff;
+  background: var(--primary);
+  color: var(--on-primary);
   cursor: pointer;
 }
 
 .controls button:hover {
-  background: #00796b;
+  background: var(--primary-container);
 }
 
 .controls button:disabled {


### PR DESCRIPTION
## Summary
- Use theme variables for radio player background so it adjusts in dark mode
- Style player controls with theme colors for proper dark mode contrast

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891564d6ff083209c3b95d2fc49d574