### PR TITLE
Use icon buttons for radio station playback

### DIFF
--- a/pakstream/css/style.css
+++ b/pakstream/css/style.css
@@ -340,8 +340,7 @@ section {
 
 /* Buttons */
 button,
-.channel-toggle,
-.play-btn {
+.channel-toggle {
   background: var(--primary);
   color: var(--on-primary);
   border: none;
@@ -351,9 +350,26 @@ button,
 }
 
 button:hover,
-.channel-toggle:hover,
-.play-btn:hover {
+.channel-toggle:hover {
   background: #004d00;
+}
+
+.play-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: #009688;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.play-btn:hover {
+  background: #00796b;
 }
 
 /* Radio player controls */
@@ -650,18 +666,13 @@ table tbody tr.favorite {
 }
 
 /* Spinner styles for radio play buttons */
-.play-btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 60px;
-}
-
 .play-btn .spinner {
   position: absolute;
   width: 16px;
   height: 16px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border: 2px solid currentColor;
   border-top-color: transparent;
   border-radius: 50%;

--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -102,376 +102,376 @@
           <th>Station</th>
         </tr>
 <tr>
-          <td><audio id="audio2001" preload="none" data-logo="/pakstream/images/stations/100-lahore.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2001" preload="none" data-logo="/pakstream/images/stations/100-lahore.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">100 FM (Lahore)</td>
         </tr>
 <tr>
-          <td><audio id="audio2002" preload="none" data-logo="/pakstream/images/stations/101-fm-karachi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2002" preload="none" data-logo="/pakstream/images/stations/101-fm-karachi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">101 FM (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2003" preload="none" data-logo="/pakstream/images/stations/aladin.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2003" preload="none" data-logo="/pakstream/images/stations/aladin.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Aladin Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio2004" preload="none" data-logo="/pakstream/images/stations/apna-107.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2004" preload="none" data-logo="/pakstream/images/stations/apna-107.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Apna</td>
         </tr>
 <tr>
-          <td><audio id="audio2005" preload="none" data-logo="/pakstream/images/stations/apna-karachi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2005" preload="none" data-logo="/pakstream/images/stations/apna-karachi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Apna FM (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2006" preload="none" data-logo="/pakstream/images/stations/big.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2006" preload="none" data-logo="/pakstream/images/stations/big.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Big FM</td>
         </tr>
 <tr>
-          <td><audio id="audio2007" preload="none" data-logo="/pakstream/images/stations/city-karachi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2007" preload="none" data-logo="/pakstream/images/stations/city-karachi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">City (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2008" preload="none" data-logo="/pakstream/images/stations/city-lahore.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2008" preload="none" data-logo="/pakstream/images/stations/city-lahore.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">City (Lahore)</td>
         </tr>
 <tr>
-          <td><audio id="audio2009" preload="none" data-logo="/pakstream/images/stations/fm-100.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2009" preload="none" data-logo="/pakstream/images/stations/fm-100.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 100</td>
         </tr>
 <tr>
-          <td><audio id="audio2011" preload="none" data-logo="/pakstream/images/stations/radio-1.png" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2011" preload="none" data-logo="/pakstream/images/stations/radio-1.png" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 91 (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2012" preload="none" data-logo="/pakstream/images/stations/91-lahore.png" src="https://cc.vmakerhost.com/proxy/lahore?mp=/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2012" preload="none" data-logo="/pakstream/images/stations/91-lahore.png" src="https://cc.vmakerhost.com/proxy/lahore?mp=/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 91 (Lahore)</td>
         </tr>
 <tr>
-          <td><audio id="audio2013" preload="none" data-logo="/pakstream/images/stations/karachi-fm-live.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2013" preload="none" data-logo="/pakstream/images/stations/karachi-fm-live.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM Karachi Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio2014" preload="none" data-logo="/pakstream/images/stations/fm-world.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2014" preload="none" data-logo="/pakstream/images/stations/fm-world.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM World</td>
         </tr>
 <tr>
-          <td><audio id="audio2015" preload="none" data-logo="/pakstream/images/stations/funcafe.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2015" preload="none" data-logo="/pakstream/images/stations/funcafe.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FunCafe Web Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio2016" preload="none" data-logo="/pakstream/images/stations/hot-fm.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2016" preload="none" data-logo="/pakstream/images/stations/hot-fm.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Hot FM</td>
         </tr>
 <tr>
-          <td><audio id="audio2017" preload="none" data-logo="/pakstream/images/stations/hot-karachi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2017" preload="none" data-logo="/pakstream/images/stations/hot-karachi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Hot FM (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2018" preload="none" data-logo="/pakstream/images/stations/mast-karachi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2018" preload="none" data-logo="/pakstream/images/stations/mast-karachi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Mast (Karachi)</td>
         </tr>
 <tr>
-          <td><audio id="audio2019" preload="none" data-logo="/pakstream/images/stations/mast-fm.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2019" preload="none" data-logo="/pakstream/images/stations/mast-fm.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Mast FM</td>
         </tr>
 <tr>
-          <td><audio id="audio2020" preload="none" data-logo="/pakstream/images/stations/mast-lahore.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2020" preload="none" data-logo="/pakstream/images/stations/mast-lahore.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Mast FM (Lahore)</td>
         </tr>
 <tr>
-          <td><audio id="audio2022" preload="none" data-logo="/pakstream/images/stations/power-99.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2022" preload="none" data-logo="/pakstream/images/stations/power-99.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Power FM 99</td>
         </tr>
 <tr>
-          <td><audio id="audio2023" preload="none" data-logo="/pakstream/images/stations/awaz-106.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2023" preload="none" data-logo="/pakstream/images/stations/awaz-106.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Awaz</td>
         </tr>
 <tr>
-          <td><audio id="audio2024" preload="none" data-logo="/pakstream/images/stations/radio.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2024" preload="none" data-logo="/pakstream/images/stations/radio.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio FM</td>
         </tr>
 <tr>
-          <td><audio id="audio2025" preload="none" data-logo="/pakstream/images/stations/jeevay.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2025" preload="none" data-logo="/pakstream/images/stations/jeevay.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Jeevay FM</td>
         </tr>
 <tr>
-          <td><audio id="audio2027" preload="none" data-logo="/pakstream/images/stations/pak-filmi.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2027" preload="none" data-logo="/pakstream/images/stations/pak-filmi.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Pak Filmi</td>
         </tr>
 <tr>
-          <td><audio id="audio2028" preload="none" data-logo="/pakstream/images/stations/riphah.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2028" preload="none" data-logo="/pakstream/images/stations/riphah.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Riphah FM (Islamabad)</td>
         </tr>
 <tr>
-          <td><audio id="audio2029" preload="none" data-logo="/pakstream/images/stations/spice-fm-107.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2029" preload="none" data-logo="/pakstream/images/stations/spice-fm-107.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Spice</td>
         </tr>
 <tr>
-          <td><audio id="audio2030" preload="none" data-logo="/pakstream/images/stations/suno-urdu-live.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2030" preload="none" data-logo="/pakstream/images/stations/suno-urdu-live.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Suno Urdu Live</td>
         </tr>
 <tr>
-          <td><audio id="audio2031" preload="none" data-logo="/pakstream/images/stations/sunrise-hasan-abda.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2031" preload="none" data-logo="/pakstream/images/stations/sunrise-hasan-abda.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Sunrise Radio FM (Hasan Abdal)</td>
         </tr>
 <tr>
-          <td><audio id="audio2032" preload="none" data-logo="/pakstream/images/stations/voa-deewa.png" src=""></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio2032" preload="none" data-logo="/pakstream/images/stations/voa-deewa.png" src=""></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">VOA Deewa</td>
         </tr>
 <tr>
-          <td><audio id="audio8" preload="none" data-logo="/pakstream/images/stations/city-fm.png" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio8" preload="none" data-logo="/pakstream/images/stations/city-fm.png" src="https://radio.cityfm89.com/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">City FM 89</td>
         </tr>
 <tr>
-          <td><audio id="audio18" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:7008/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio18" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:7008/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Islamabad</td>
         </tr>
 <tr>
-          <td><audio id="audio19" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8048/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio19" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8048/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Karachi</td>
         </tr>
 <tr>
-  <td><audio id="audio104" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8056/stream"></audio><button class="play-btn">Play</button></td>
+  <td><audio id="audio104" preload="none" data-logo="/pakstream/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8056/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
   <td class="station-name">FM 101 Lahore</td>
 </tr>
 
 <tr>
-          <td><audio id="audio51" preload="none" data-logo="/pakstream/images/stations/pbc-lahore.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio51" preload="none" data-logo="/pakstream/images/stations/pbc-lahore.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">PBC (Lahore)</td>
         </tr>
 <tr>
-          <td><audio id="audio50" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio50" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Pakistan Islamabad</td>
         </tr>
 <tr>
-          <td><audio id="audio59" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio59" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Samaa FM 107.4</td>
         </tr>
 <tr>
-          <td><audio id="audio40" preload="none" data-logo="/pakstream/images/stations/mera-1074.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio40" preload="none" data-logo="/pakstream/images/stations/mera-1074.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Mera FM</td>
         </tr>
 <tr>
-          <td><audio id="audio35" preload="none" data-logo="/pakstream/images/stations/hum.png" src="https://server.mediacast4u.stream/8002/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio35" preload="none" data-logo="/pakstream/images/stations/hum.png" src="https://server.mediacast4u.stream/8002/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Hum FM 106.2</td>
         </tr>
 <tr>
-          <td><audio id="audio83" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio83" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Lahore MW</td>
         </tr>
 <tr>
-          <td><audio id="audio100" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8078/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio100" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8078/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Mirpur</td>
         </tr>
 <tr>
-          <td><audio id="audio95" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio95" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Peshawar</td>
         </tr>
 <tr>
-          <td><audio id="audio20" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8050/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio20" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8050/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Larkana</td>
         </tr>
 <tr>
-          <td><audio id="audio21" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8052/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio21" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8052/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Mithi</td>
         </tr>
 <tr>
-          <td><audio id="audio32" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio32" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 94.4</td>
         </tr>
 <tr>
-          <td><audio id="audio90" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/MW639khi?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio90" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/MW639khi?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">MW 639 Karachi</td>
         </tr>
 <tr>
-          <td><audio id="audio42" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio42" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Multan MW</td>
         </tr>
 <tr>
-          <td><audio id="audio96" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8072/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio96" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8072/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Peshawar MW</td>
         </tr>
 <tr>
-          <td><audio id="audio93" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8060/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio93" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8060/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Quetta MW</td>
         </tr>
 <tr>
-          <td><audio id="audio81" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8024/#?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio81" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8024/#?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Faisalabad</td>
         </tr>
 <tr>
-          <td><audio id="audio80" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8092/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio80" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8092/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Bahawalpur MW</td>
         </tr>
 <tr>
-          <td><audio id="audio103" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio103" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Azad Kashmir Radio Mirpur</td>
         </tr>
 <tr>
-          <td><audio id="audio89" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8054/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio89" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8054/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Khairpur</td>
         </tr>
 <tr>
-          <td><audio id="audio94" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8062/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio94" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8062/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Khuzdar MW 567</td>
         </tr>
 <tr>
-          <td><audio id="audio99" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/Dikhan?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio99" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/Dikhan?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">D.I. Khan MW 711</td>
         </tr>
 <tr>
-          <td><audio id="audio79" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8020/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio79" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8020/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Bahawalpur</td>
         </tr>
 <tr>
-          <td><audio id="audio67" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio67" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Saut-ul-Quran</td>
         </tr>
 <tr>
-          <td><audio id="audio61" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio61" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</td>
         </tr>
 <tr>
-          <td><audio id="audio57" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio57" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Pakistan World Service</td>
         </tr>
 <tr>
-          <td><audio id="audio58" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio58" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Pakistan WS</td>
         </tr>
 <tr>
-          <td><audio id="audio69" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio69" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Islamabad Station</td>
         </tr>
 <tr>
-          <td><audio id="audio31" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://s33.myradiostream.com:13872/listen.m4a"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio31" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://s33.myradiostream.com:13872/listen.m4a"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 92</td>
         </tr>
 <tr>
-          <td><audio id="audio30" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio30" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">fm...</td>
         </tr>
 <tr>
-          <td><audio id="audio87" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8042/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio87" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8042/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Hyderabad MW 1008KHz</td>
         </tr>
 <tr>
-          <td><audio id="audio86" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8040/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio86" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8040/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Sargodha</td>
         </tr>
 <tr>
-          <td><audio id="audio98" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8064/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio98" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8064/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Abbotabad</td>
         </tr>
 <tr>
-          <td><audio id="audio88" preload="none" data-logo="/pakstream/images/stations/hyderabad-fm.png" src="https://whmsonic.radio.gov.pk:8044/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio88" preload="none" data-logo="/pakstream/images/stations/hyderabad-fm.png" src="https://whmsonic.radio.gov.pk:8044/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Hyderabad</td>
         </tr>
 <tr>
-          <td><audio id="audio84" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio84" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Multan</td>
         </tr>
 <tr>
-          <td><audio id="audio37" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://cdn.voscast.com/resources/?key=4e1e2d7ac97ea7ad9493c529df2ab16c&amp;c=wmp"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio37" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://cdn.voscast.com/resources/?key=4e1e2d7ac97ea7ad9493c529df2ab16c&amp;c=wmp"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Insaf Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio39" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio39" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Love-Islam-Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio45" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio45" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Mirpur</td>
         </tr>
 <tr>
-          <td><audio id="audio82" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/fm94lhr"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio82" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/fm94lhr"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 94 Lahore</td>
         </tr>
 <tr>
-          <td><audio id="audio6" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio6" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">All4Masti</td>
         </tr>
 <tr>
-          <td><audio id="audio68" preload="none" data-logo="/pakstream/images/stations/planet-87-6.png" src="https://whmsonic.radio.gov.pk:7042/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio68" preload="none" data-logo="/pakstream/images/stations/planet-87-6.png" src="https://whmsonic.radio.gov.pk:7042/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Planet FM 87.6</td>
         </tr>
 <tr>
-          <td><audio id="audio36" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio36" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">ILM Radio Renala FM 92</td>
         </tr>
 <tr>
-          <td><audio id="audio64" preload="none" data-logo="/pakstream/images/stations/pakistan-toronto.png" src="https://s3.radio.co/s3b10a57ef/listen"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio64" preload="none" data-logo="/pakstream/images/stations/pakistan-toronto.png" src="https://s3.radio.co/s3b10a57ef/listen"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Radio Pakistan Toronto</td>
         </tr>
 <tr>
-          <td><audio id="audio60" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://s97.radiolize.com:8040/radio.mp3"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio60" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://s97.radiolize.com:8040/radio.mp3"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Shopen Anime Radio</td>
         </tr>
 <tr>
-          <td><audio id="audio70" preload="none" data-logo="/pakstream/images/stations/ncac.png" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio70" preload="none" data-logo="/pakstream/images/stations/ncac.png" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">NCAC</td>
         </tr>
 <tr>
-          <td><audio id="audio72" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7006/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio72" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7006/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">External Service</td>
         </tr>
 <tr>
-          <td><audio id="audio75" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7008/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio75" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7008/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Chalte Chalte</td>
         </tr>
 <tr>
-          <td><audio id="audio74" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8094/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio74" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8094/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Technology channel</td>
         </tr>
 <tr>
-          <td><audio id="audio73" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7007/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio73" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7007/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">Sports & Health Channel</td>
         </tr>
 <tr>
-          <td><audio id="audio24" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7022/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio24" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7022/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Karachi</td>
         </tr>
 <tr>
-          <td><audio id="audio25" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8088/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio25" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8088/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Lahore</td>
         </tr>
 <tr>
-          <td><audio id="audio28" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8036/relay"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio28" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8036/relay"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Rawalpindi</td>
         </tr>
 <tr>
-          <td><audio id="audio23" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8022/relay"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio23" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8022/relay"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Faisalabad</td>
         </tr>
 <tr>
-          <td><audio id="audio27" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio27" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Multan</td>
         </tr>
 <tr>
-          <td><audio id="audio26" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8028/relay"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio26" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8028/relay"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Mianwali</td>
         </tr>
 <tr>
-          <td><audio id="audio22" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8066/relay"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio22" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8066/relay"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 93 Chitral</td>
         </tr>
 <tr>
-          <td><audio id="audio1" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio1" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">#radio quran</td>
         </tr>
 <tr>
-          <td><audio id="audio97" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8068/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio97" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8068/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Kohat</td>
         </tr>
 <tr>
-          <td><audio id="audio92" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8058/stream?type=http&amp;nocache=12"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio92" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8058/stream?type=http&amp;nocache=12"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Quetta</td>
         </tr>
 <tr>
-          <td><audio id="audio85" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8038/relay?type=http&amp;nocache=9"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio85" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8038/relay?type=http&amp;nocache=9"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">FM 101 Sialkot</td>
         </tr>
 <tr>
-          <td><audio id="audio65" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://samaapew107-itelservices.radioca.st/stream"></audio><button class="play-btn">Play</button></td>
+          <td><audio id="audio65" preload="none" data-logo="/pakstream/images/default_radio.png" src="https://samaapew107-itelservices.radioca.st/stream"></audio><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button></td>
           <td class="station-name">SAMAA FM Peshawar 107.4</td>
         </tr>
       </tbody>
@@ -577,7 +577,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!btn) return;
     btn.classList.remove('loading');
     const label = btn.querySelector('.label');
-    if (label) label.textContent = 'Play';
+    if (label) label.textContent = 'play_arrow';
+    btn.setAttribute('aria-label', 'Play');
   }
 
   function stopStation() {
@@ -652,9 +653,10 @@ document.addEventListener('DOMContentLoaded', function() {
   playButtons.forEach(btn => {
     const audio = btn.parentElement.querySelector('audio');
     const name = btn.closest('tr').querySelector('.station-name').textContent;
-    const text = btn.textContent.trim();
+    btn.classList.remove('material-icons');
     btn.setAttribute('type', 'button');
-    btn.innerHTML = `<span class="label">${text}</span><span class="spinner"></span>`;
+    btn.setAttribute('aria-label', 'Play');
+    btn.innerHTML = `<span class="material-icons label">play_arrow</span><span class="spinner"></span>`;
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       if (btn === currentBtn) {
@@ -705,7 +707,8 @@ document.addEventListener('DOMContentLoaded', function() {
   playPauseBtn.addEventListener('click', () => {
     if (mainPlayer.paused) {
       const label = currentBtn?.querySelector('.label');
-      if (label) label.textContent = 'Stop';
+      if (label) label.textContent = 'stop';
+      currentBtn?.setAttribute('aria-label', 'Stop');
       mainPlayer.play();
     } else {
       mainPlayer.pause();
@@ -723,11 +726,13 @@ document.addEventListener('DOMContentLoaded', function() {
     notLiveBadge.hidden = true;
     if (pendingBtn) {
       pendingBtn.classList.remove('loading');
-      pendingBtn.querySelector('.label').textContent = 'Stop';
+      pendingBtn.querySelector('.label').textContent = 'stop';
+      pendingBtn.setAttribute('aria-label', 'Stop');
       currentBtn = pendingBtn;
       pendingBtn = null;
     } else if (currentBtn) {
-      currentBtn.querySelector('.label').textContent = 'Stop';
+      currentBtn.querySelector('.label').textContent = 'stop';
+      currentBtn.setAttribute('aria-label', 'Stop');
     }
   });
 


### PR DESCRIPTION
## Summary
- render station list buttons with Material icons instead of text
- add icon+spinner markup and remove font conflict so buttons match player styling and show loading animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891576f978483208d3995a3584e957a