### PR TITLE
Enable lock screen station navigation

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -612,11 +612,18 @@ document.addEventListener('DOMContentLoaded', function() {
       stationLogo.onerror = null;
       stationLogo.src = defaultLogo;
     };
-    stationLogo.src = audio.dataset.logo || defaultLogo;
+    const logoSrc = audio.dataset.logo || defaultLogo;
+    stationLogo.src = logoSrc;
     stationLogo.hidden = false;
     liveBadge.hidden = true;
     notLiveBadge.hidden = false;
     mainPlayer.src = audio.src;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: name,
+        artwork: [{ src: logoSrc }]
+      });
+    }
     mainPlayer.load();
     const playPromise = mainPlayer.play();
     if (playPromise !== undefined) {
@@ -704,6 +711,11 @@ document.addEventListener('DOMContentLoaded', function() {
   prevBtn.addEventListener('click', () => playStation(-1));
   nextBtn.addEventListener('click', () => playStation(1));
 
+  if ('mediaSession' in navigator) {
+    navigator.mediaSession.setActionHandler('previoustrack', () => playStation(-1));
+    navigator.mediaSession.setActionHandler('nexttrack', () => playStation(1));
+  }
+
   playPauseBtn.addEventListener('click', () => {
     if (mainPlayer.paused) {
       const label = currentBtn?.querySelector('.label');
@@ -724,6 +736,9 @@ document.addEventListener('DOMContentLoaded', function() {
     playPauseBtn.textContent = 'pause';
     liveBadge.hidden = false;
     notLiveBadge.hidden = true;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = 'playing';
+    }
     if (pendingBtn) {
       pendingBtn.classList.remove('loading');
       pendingBtn.querySelector('.label').textContent = 'stop';
@@ -747,6 +762,9 @@ document.addEventListener('DOMContentLoaded', function() {
     playPauseBtn.textContent = 'play_arrow';
     liveBadge.hidden = true;
     notLiveBadge.hidden = false;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = 'paused';
+    }
   });
 
   mainPlayer.addEventListener('error', () => {


### PR DESCRIPTION
## Summary
- Set Media Session metadata for current station and hook lock-screen next/previous actions
- Update playback state so media controls reflect play/pause correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915be8c7548320a9268bf11a97566a