### PR TITLE
Refactor style.css for color consistency

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,4 @@
+/* Refactored style.css with color consistency */
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 [hidden] {
@@ -23,7 +24,7 @@ body {
   padding: 0 16px;
   height: 56px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  border-bottom: 2px solid #004d00;
+  border-bottom: 2px solid var(--primary-container);
   position: relative;
   z-index: 1002;
 }
@@ -74,7 +75,7 @@ nav a {
 nav a:hover,
 nav a.active {
   text-decoration: underline;
-  color: #c5e1a5;
+  color: var(--primary-container);
 }
 
 #nav-toggle {
@@ -187,7 +188,7 @@ section {
 
 .blog-post-item {
   padding: 12px 16px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--surface-variant);
 }
 
 .blog-post-item:last-child {
@@ -208,7 +209,7 @@ section {
   display: block;
   margin-top: 4px;
   font-size: 0.875rem;
-  color: #777;
+  color: var(--on-surface-variant);
 }
 
 /* Channel navigation layout */
@@ -271,7 +272,7 @@ section {
   display: flex;
   align-items: center;
   padding: 8px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--surface-variant);
   cursor: pointer;
 }
 
@@ -294,7 +295,7 @@ section {
 
 .video-list .video-item .video-meta {
   font-size: 0.875rem;
-  color: #777;
+  color: var(--on-surface-variant);
 }
 
 /* Responsive behaviour for channel list */
@@ -351,7 +352,7 @@ button,
 
 button:hover,
 .channel-toggle:hover {
-  background: #004d00;
+  background: var(--primary-container);
 }
 
 .play-btn {
@@ -363,8 +364,8 @@ button:hover,
   height: 40px;
   border: none;
   border-radius: 50%;
-  background: #009688;
-  color: #ffffff;
+  background: var(--primary);
+  color: var(--on-primary);
   cursor: pointer;
 }
 
@@ -373,7 +374,7 @@ button:hover,
 }
 
 .play-btn:hover {
-  background: #00796b;
+  background: var(--primary-container);
 }
 
 /* Radio player controls */
@@ -410,8 +411,8 @@ button:hover,
   margin-top: 4px;
   padding: 2px 6px;
   border-radius: 12px;
-  background: #ffebee;
-  color: #d32f2f;
+  background: var(--error-container, #ffebee);
+  color: var(--error);
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -419,7 +420,7 @@ button:hover,
 .live-badge .dot {
   width: 8px;
   height: 8px;
-  background: #d32f2f;
+  background: var(--error);
   border-radius: 50%;
   margin-right: 4px;
 }
@@ -430,8 +431,8 @@ button:hover,
   margin-top: 4px;
   padding: 2px 6px;
   border-radius: 12px;
-  background: #eee;
-  color: #616161;
+  background: var(--surface-variant);
+  color: var(--on-surface-variant);
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -439,7 +440,7 @@ button:hover,
 .not-live-badge .dot {
   width: 8px;
   height: 8px;
-  background: #616161;
+  background: var(--on-surface-variant);
   border-radius: 50%;
   margin-right: 4px;
 }
@@ -482,7 +483,7 @@ table {
 
 th, td {
   padding: 8px;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--surface-variant);
 }
 
 th {
@@ -545,12 +546,12 @@ table tbody tr.favorite {
 .post h1 {
   font-size: 2em;
   margin-bottom: 10px;
-  color: #263238;
+  color: var(--on-surface);
 }
 
 .post-meta,
 .post-author {
-  color: #777;
+  color: var(--on-surface-variant);
   font-size: 0.9em;
   margin-bottom: 8px;
 }
@@ -565,20 +566,20 @@ table tbody tr.favorite {
 .post-content {
   line-height: 1.7;
   font-size: 1em;
-  color: #333;
+  color: var(--on-surface);
 }
 
 .post-share {
   margin-top: 30px;
   font-size: 0.9em;
   padding-top: 15px;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid var(--outline);
 }
 
 .post-share a {
   text-decoration: none;
   margin-right: 10px;
-  color: #1E88E5;
+  color: var(--accent-link);
 }
 
 .post-share a:hover {
@@ -711,7 +712,7 @@ table tbody tr.favorite {
 .utility-page canvas,
 .utility-page img {
   max-width: 100%;
-  border: 1px solid #ccc;
+  border: 1px solid var(--outline);
   margin-top: 1rem;
   border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- replace hex colors with theme variables in navigation, lists, posts, and badges
- update play buttons and utility media borders to use primary and outline tokens

## Testing
- `npm test` (fails: Could not read package.json)
- `jekyll build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6891d314efa08320a07bc55559e47d4f