### PR TITLE
feat: expand theme variables for hover and error states

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,7 +23,7 @@ body {
   padding: 0 16px;
   height: 56px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  border-bottom: 2px solid #004d00;
+  border-bottom: 2px solid var(--hover-primary);
   position: relative;
   z-index: 1002;
 }
@@ -74,7 +74,7 @@ nav a {
 nav a:hover,
 nav a.active {
   text-decoration: underline;
-  color: #c5e1a5;
+  color: var(--hover-link);
 }
 
 #nav-toggle {
@@ -202,6 +202,7 @@ section {
 
 .blog-post-item a:hover {
   text-decoration: underline;
+  color: var(--hover-link);
 }
 
 .blog-post-item .post-date {
@@ -351,7 +352,7 @@ button,
 
 button:hover,
 .channel-toggle:hover {
-  background: #004d00;
+  background: var(--hover-primary);
 }
 
 .play-btn {
@@ -373,7 +374,7 @@ button:hover,
 }
 
 .play-btn:hover {
-  background: #00796b;
+  background: var(--hover-primary);
 }
 
 /* Radio player controls */
@@ -466,7 +467,7 @@ button:hover,
 }
 
 .controls button:hover {
-  background: var(--primary-container);
+  background: var(--hover-primary);
 }
 
 .controls button:disabled {
@@ -503,7 +504,7 @@ table tbody tr.favorite {
   }
 
   .radio-list table tbody tr:not(:first-child):hover {
-    background-color: var(--surface-variant);
+    background-color: var(--hover-primary);
   }
 }
 
@@ -583,6 +584,7 @@ table tbody tr.favorite {
 
 .post-share a:hover {
   text-decoration: underline;
+  color: var(--hover-link);
 }
 
 /* Responsive adjustments */
@@ -739,6 +741,7 @@ footer nav a {
 
 footer nav a:hover {
   text-decoration: underline;
+  color: var(--hover-link);
 }
 
 .ad-container {

--- a/css/theme.css
+++ b/css/theme.css
@@ -18,6 +18,8 @@
 
   --error: #D32F2F;
   --on-error: #FFFFFF;
+  --error-container: #FFEBEE;
+  --on-error-container: #B71C1C;
 
   --outline: #BDBDBD;
   --surface-variant: #EEEEEE;
@@ -28,6 +30,8 @@
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
   --favorite-row: #e8f5e9;
+  --hover-primary: #004d00;
+  --hover-link: #1565C0;
 }
 
 /* -------- Dark Theme -------- */
@@ -48,6 +52,8 @@
 
   --error: #EF9A9A;
   --on-error: #3C0404;
+  --error-container: #5C0000;
+  --on-error-container: #FFCDD2;
 
   --outline: #424242;
   --surface-variant: #2C2C2C;
@@ -58,4 +64,6 @@
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
   --favorite-row: #1B5E20;
+  --hover-primary: #00695C;
+  --hover-link: #64B5F6;
 }


### PR DESCRIPTION
## Summary
- add error-container, on-error-container, hover-primary and hover-link CSS variables for light and dark themes
- apply hover-primary and hover-link variables throughout style.css for consistent hover behavior

## Testing
- `npx stylelint "css/*.css"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_6891d38d81508320949edf769f541da6