### PR TITLE
Fix spinner animation on radio page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -719,8 +719,11 @@ table tbody tr.favorite {
 }
 
 @keyframes spin {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
   to {
-    transform: rotate(360deg);
+    transform: translate(-50%, -50%) rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix radio player spinner keyframes so loader stays centered and spins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e97de6448320ab847ad338291c93