### PR TITLE
fix: reset previous station button when switching

### DIFF
--- a/pakstream/radio.html
+++ b/pakstream/radio.html
@@ -752,6 +752,9 @@ document.addEventListener('DOMContentLoaded', function() {
       navigator.mediaSession.playbackState = 'playing';
     }
     if (pendingBtn) {
+      if (currentBtn && currentBtn !== pendingBtn) {
+        resetButton(currentBtn);
+      }
       pendingBtn.classList.remove('loading');
       pendingBtn.querySelector('.label').textContent = 'stop';
       pendingBtn.setAttribute('aria-label', 'Stop');
@@ -764,12 +767,13 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  mainPlayer.addEventListener('waiting', () => {
-    liveBadge.hidden = true;
-    notLiveBadge.hidden = false;
-    playPauseBtn.classList.add('loading');
-    currentBtn?.classList.add('loading');
-  });
+    mainPlayer.addEventListener('waiting', () => {
+      liveBadge.hidden = true;
+      notLiveBadge.hidden = false;
+      playPauseBtn.classList.add('loading');
+      const targetBtn = pendingBtn || currentBtn;
+      targetBtn?.classList.add('loading');
+    });
 
   mainPlayer.addEventListener('pause', () => {
     if (!mainPlayer.src) return;


### PR DESCRIPTION
## Summary
- prevent previous radio station button from displaying loading spinner when switching stations
- restore play icon on the previously playing station's button once a new station starts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891efe584808320984d5f76ca3631f1