### PR TITLE
feat: keep radio player visible while scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,12 @@ button:hover,
   align-items: center;
 }
 
+.radio-list #player-container {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
 .station-info {
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- make radio player sticky so it stays visible while scrolling through long station lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f5cd401c8320891b5965e2bc28e2