### PR TITLE
Fix undefined iframe src causing 404 on TV and YouTube pages

### DIFF
--- a/pakstream/tv.html
+++ b/pakstream/tv.html
@@ -229,7 +229,9 @@
 
     function loadPlayer(id) {
       const iframe = document.getElementById(`${id}-player`);
-      iframe.src = iframe.dataset.src;
+      if (iframe.dataset.src && !iframe.src) {
+        iframe.src = iframe.dataset.src;
+      }
       players[iframe.id] = new YT.Player(iframe.id, {
         playerVars: { autoplay: 1 },
         events: {

--- a/pakstream/youtube.html
+++ b/pakstream/youtube.html
@@ -170,7 +170,9 @@
   }
 
   function loadVideo(videoId) {
-    playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+    if (videoId) {
+      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+    }
   }
 
   function timeAgo(dateString) {


### PR DESCRIPTION
## Summary
- Guard against missing `data-src` before assigning iframe `src` on TV page
- Guard against missing video IDs when assigning iframe `src` on YouTube page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924ed3d47c8320bf7c70580d0a55e6