### PR TITLE
Refine theme colors and dark-mode behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,10 @@
 /* Refactored style.css with improved readability & polished UI/UX */
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
+html {
+  color-scheme: light dark;
+}
+
 :focus-visible {
   outline: 2px dashed var(--accent-link);
   outline-offset: 2px;

--- a/css/theme.css
+++ b/css/theme.css
@@ -30,7 +30,7 @@
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
   --favorite-row: #e8f5e9;
-  --hover-primary: #004d00;
+  --hover-primary: #00695C;
   --hover-link: #1565C0;
 }
 
@@ -63,7 +63,42 @@
   --accent-link: #90CAF9;
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
-  --favorite-row: #1B5E20;
+  --favorite-row: #2E7D32;
   --hover-primary: #00695C;
   --hover-link: #64B5F6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: #80CBC4;
+    --on-primary: #00332C;
+    --primary-container: #004D40;
+    --on-primary-container: #B2DFDB;
+
+    --secondary: #EF9A9A;
+    --on-secondary: #3C0404;
+
+    --background: #121212;
+    --on-background: #E0E0E0;
+
+    --surface: #1E1E1E;
+    --on-surface: #F5F5F5;
+
+    --error: #EF9A9A;
+    --on-error: #3C0404;
+    --error-container: #5C0000;
+    --on-error-container: #FFCDD2;
+
+    --outline: #424242;
+    --surface-variant: #2C2C2C;
+    --on-surface-variant: #DDDDDD;
+
+    --accent-live: #FFB74D;
+    --accent-link: #90CAF9;
+    --accent-success: #66BB6A;
+    --accent-info: #81D4FA;
+    --favorite-row: #2E7D32;
+    --hover-primary: #00695C;
+    --hover-link: #64B5F6;
+  }
 }


### PR DESCRIPTION
## Summary
- lighten hover green in light theme and brighten favorite row in dark theme
- add `prefers-color-scheme` fallback and global `color-scheme` property for better OS dark-mode support

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689264c86a308320a92de7a29a98a9dc