### PR TITLE
Improve favorite row styling and player gradient

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -409,7 +409,7 @@ button:hover,
 
 /* Radio player controls */
 .radio-player {
-  background: linear-gradient(180deg, var(--surface), var(--surface-variant));
+  background: linear-gradient(180deg, #1E1E1E, #2C2C2C);
   padding: 16px;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
@@ -532,6 +532,7 @@ table tbody tr:not(:first-child) {
 
 table tbody tr.favorite {
   background-color: var(--favorite-row);
+  color: #FFFFFF;
 }
 /* Hover highlight for station rows on desktops */
 @media (hover: hover) and (pointer: fine) {

--- a/css/theme.css
+++ b/css/theme.css
@@ -29,7 +29,7 @@
   --accent-link: #1E88E5;
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
-  --favorite-row: #e8f5e9;
+  --favorite-row: #2E7D32;
   --hover-primary: #00695C;
   --hover-link: #1565C0;
 }


### PR DESCRIPTION
## Summary
- darken the favorite row background variable for improved contrast
- ensure favorite rows display white text for readability
- apply a fixed dark gradient to the radio player container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689266091e8083209303d0b0af80906b